### PR TITLE
Fixed issue when rootDir contains spaces.

### DIFF
--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -36,7 +36,7 @@
 @set PATH=%PATH%;%rootDir%\bin;%git_install_root%\bin;%git_install_root%\mingw\bin;%git_install_root%\cmd;
 
 :: Add aliases
-@doskey /macrofile=%rootDir%\config\aliases
+@doskey /macrofile="%rootDir%\config\aliases"
 
 
 :: cd into users homedir


### PR DESCRIPTION
If I place cmder in a path that contains spaces it spits out a bunch of messages on startup. In the example below I have cmder in `C:\Users\jyggen\Test Folder\cmder` (messages translated from swedish, so might not be accurate).

```
Invalid macro definition.
Unable to find file - C:\Users\jyggen\Test
Welcome to cmder!
```

Not sure if this is the right way to solve it, but the messages are gone with this PR and aliases seems to work as expected.
