### PR TITLE
Add absolute path to launcher

### DIFF
--- a/Cmder.bat
+++ b/Cmder.bat
@@ -1,2 +1,3 @@
 @echo off
-start %~dp0/vendor/conemu-maximus5/ConEmu.exe /Title Cmder /LoadCfgFile ../../config/ConEmu.xml
+@set rootDir=%~dp0
+start %rootDir%vendor/conemu-maximus5/ConEmu.exe /Title Cmder /LoadCfgFile %rootDir%config/ConEmu.xml

--- a/config/ConEmu.xml
+++ b/config/ConEmu.xml
@@ -488,7 +488,7 @@
 						<key name="Task1" modified="2013-11-03 17:59:09" build="130827">
 					<value name="Name" type="string" data="{cmd}"/>
 					<value name="GuiArgs" type="string" data=" /icon &quot;cmd.exe&quot;"/>
-					<value name="Cmd1" type="string" data="cmd /k vendor\init.bat"/>
+					<value name="Cmd1" type="string" data="cmd /k %rootDir%vendor\init.bat"/>
 					<value name="Active" type="dword" data="00000000"/>
 					<value name="Count" type="dword" data="00000001"/>
 				</key>

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -2,16 +2,14 @@
 :: Sets some nice defaults
 :: Created as part of cmder project
 
-
 :: Seting  prompt style
 @for /f "tokens=2 delims=:." %%x in ('chcp') do @set cp=%%x
 :: The slow part
 :: World without Unicode is a sad world
 @chcp 65001>nul
 :: It has to be lambda, I already made a logo
-@prompt $E[1;32;40m$P$S{git}$S$_$E[1;30;40mλ$S$E[0m
+@prompt $E[1;32;40m$P $_$E[1;30;40mλ $E[0m
 @chcp %cp%>nul
-
 
 :: Pick right version of clink
 @if "%PROCESSOR_ARCHITECTURE%"=="x86" (
@@ -20,28 +18,24 @@
     set architecture=64
 )
 
-
 :: Run clink
-@vendor\clink\clink_x%architecture%.exe inject --quiet --profile config
+@%rootDir%vendor\clink\clink_x%architecture%.exe inject --quiet --profile config
 
 :: Prepare for msysgit
-
 :: I do not even know, copypasted from their .bat
+@if not exist "%HOME%" @set HOME=%HOMEDRIVE%%HOMEPATH%
+@if not exist "%HOME%" @set HOME=%USERPROFILE%
 @set PLINK_PROTOCOL=ssh
 @if not defined TERM set TERM=msys
 
 :: Enhance Path
-@set rootDir=%CD%
 @set git_install_root=%CD%\vendor\msysgit
 @set PATH=%PATH%;%rootDir%\bin;%git_install_root%\bin;%git_install_root%\mingw\bin;%git_install_root%\cmd;
 
 :: Add aliases
-@doskey /macrofile="%rootDir%\config\aliases"
-
+@doskey /macrofile=%rootDir%\config\aliases
 
 :: cd into users homedir
-@cd /d %USERPROFILE%
+@cd /d "%userprofile%"
 
-:: Set home path
-@set HOME=%USERPROFILE%
 @echo Welcome to cmder!


### PR DESCRIPTION
Add absolute path to the launcher so you don't have to be in the correct directory to be able to start it.
