### PR TITLE
Update batch file to ensure that Cmder always loads correctly regardless...

### DIFF
--- a/Cmder.bat
+++ b/Cmder.bat
@@ -1,2 +1,3 @@
 @echo off
+cd /d %~dp0
 start vendor/conemu-maximus5/ConEmu.exe /Title Cmder /LoadCfgFile ../../config/ConEmu.xml


### PR DESCRIPTION
... of working directory

The addition of a line to change to the script directory ensures that Cmder will always load correctly, regardless of the current working directory. I found that I needed to add this line to get it working correctly as a shortcut in my Start menu, for example.
