### PR TITLE
Fix line ending handling if autocrlf is false.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto


### PR DESCRIPTION
If you have set autocrlf=false in global git config you have some strange issues like init.bat is checked out with unix line endings and does not work properly. This patch adds autocrlf behavior as per-repository setting (see https://help.github.com/articles/dealing-with-line-endings).
