### PR TITLE
change TERM to xterm

### DIFF
--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -28,7 +28,9 @@
 
 :: I do not even know, copypasted from their .bat
 @set PLINK_PROTOCOL=ssh
-@if not defined TERM set TERM=msys
+
+:: Set TERM to xterm so less, diff, etc. show properly
+@if not defined TERM set TERM=xterm
 
 :: Enhance Path
 @set rootDir=%CD%


### PR DESCRIPTION
Changing the TERM environment variable to xterm. This will allow you to ssh into another box and run tmux or screen properly.

This should fix #44 and #50.
