### PR TITLE
Change TERM from msys to cygwin.

### DIFF
--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -29,7 +29,7 @@
 
 :: I do not even know, copypasted from their .bat
 @set PLINK_PROTOCOL=ssh
-@if not defined TERM set TERM=msys
+@if not defined TERM set TERM=cygwin
 
 :: Enhance Path
 @set git_install_root=%rootDir%\vendor\msysgit


### PR DESCRIPTION
Change TERM from msys to cygwin.

Set `TERM=cygwin` as that actually exists in common terminfo databases.
msys is a fork of cygwin so this is definitely the most compatible thing to do.

`msys` is a loose alias for `cygwin` in msysgit. From the [msysgit termcap](https://github.com/msysgit/msysgit/blob/master/etc/termcap#L165):

```
cygwin:\
        :xn@:op=\E[39;49m:Km=\E[M:tc=linux:

msys:\
        :xn@:op=\E[39;49m:Km=\E[M:tc=linux:tc=rxvt:
```

This used to be a direct alias to cygwin in the past. Not sure what the purpose of the new addition is here. It looks to be adding mostly eccentric capabilities that `cmd` does not support. `man terminfo` if you want to try to understand what the things below mean. Everything works fine for me after the switch.

```
$ infocmp -L cygwin msys
comparing cygwin to msys.
    comparing booleans.
        has_meta_key: F:T.
    comparing numbers.
    comparing strings.
        cursor_visible: NULL, '\E[?25h'.
        enter_ca_mode: NULL, '\E7\E[?47h'.
        exit_ca_mode: NULL, '\E[2J\E[?47l\E8'.
        init_1string: NULL, '\E[?47l\E=\E[?1l'.
        init_2string: NULL, '\E[r\E[m\E[2J\E[H\E[?7h\E[?1;3;4;6l\E[4l'.
        key_a1: NULL, '\EOw'.
        key_a3: NULL, '\EOy'.
        key_c1: NULL, '\EOq'.
        key_c3: NULL, '\EOs'.
        key_f0: NULL, '\E[21~'.
        keypad_local: NULL, '\E>'.
        keypad_xmit: NULL, '\E='.
        parm_down_cursor: NULL, '\E[%p1%dB'.
        parm_left_cursor: NULL, '\E[%p1%dD'.
        parm_right_cursor: NULL, '\E[%p1%dC'.
        parm_up_cursor: NULL, '\E[%p1%dA'.
```

Of course, one could also just install the msys entry to the server being SSHed into:

```
$ wget https://raw.github.com/msysgit/msysgit/master/etc/termcap
$ tic -e msys termcap
```

Would close #44, #50, and #56.
