### PR TITLE
Make application use Cmder icon

### DIFF
--- a/config/ConEmu.xml
+++ b/config/ConEmu.xml
@@ -487,7 +487,7 @@
 				<value name="Count" type="dword" data="00000002"/>
 						<key name="Task1" modified="2013-11-29 16:19:41" build="131107">
 					<value name="Name" type="string" data="{cmd}"/>
-					<value name="GuiArgs" type="string" data=" /icon &quot;cmd.exe&quot;"/>
+					<value name="GuiArgs" type="string" data=" /icon &quot;%CMDER_ROOT%\cmder.exe&quot;"/>
 					<value name="Cmd1" type="string" data="cmd /k &quot;%CMDER_ROOT%\vendor\init.bat&quot;  -new_console:d:%USERPROFILE%"/>
 					<value name="Active" type="dword" data="00000000"/>
 					<value name="Count" type="dword" data="00000001"/>


### PR DESCRIPTION
Use the Cmder icon for the application instead of the Cmd.exe icon
