### PR TITLE
Making the batch file paths more robust.

### DIFF
--- a/Cmder.bat
+++ b/Cmder.bat
@@ -1,3 +1,3 @@
 @echo off
 SET CMDER_ROOT=%~dp0
-start %~dp0/vendor/conemu-maximus5/ConEmu.exe /Icon "%CMDER_ROOT%\icons\cmder.ico" /Title Cmder /LoadCfgFile "%CMDER_ROOT%\config\ConEmu.xml"
+start "%CMDER_ROOT%vendor\conemu-maximus5\ConEmu.exe" /Icon "%CMDER_ROOT%icons\cmder.ico" /Title Cmder /LoadCfgFile "%CMDER_ROOT%config\ConEmu.xml"


### PR DESCRIPTION
Use the current path variable to set all the cmd line parameters.
Quote the file path string to handle paths with a space in
Use backslashes for windows folder paths
Remove double slash in paths using `CMDER_ROOT` as %-dp0 ends in '\'
