### PR TITLE
Allow for existing HOME variable

### DIFF
--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -32,4 +32,8 @@
 :: Set home path
 @if not defined HOME set HOME=%USERPROFILE%
 
-@if defined CMDER_START cd /d "%CMDER_START%"
+@if defined CMDER_START (
+    @cd /d "%CMDER_START%"
+) else (
+    @cd /d "%HOME%"
+)


### PR DESCRIPTION
If the user already has a HOME variable set then it should be honored:
- Don't re-set HOME to USERPROFILE
- Change to the HOME directory unless some other directory has been specified.
