### PR TITLE
Change in the selection of the executable to clink

### DIFF
--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -7,10 +7,10 @@
 @prompt $E[1;32;40m$P$S{git}$S$_$E[1;30;40m{lamb}$S$E[0m
 
 :: Pick right version of clink
-@if "%PROCESSOR_ARCHITECTURE%"=="x86" (
-    set architecture=86
-) else (
+@if "%PROCESSOR_ARCHITECTURE:~-2%"=="64" (
     set architecture=64
+) else (
+    set architecture=86
 )
 
 :: Run clink


### PR DESCRIPTION
There is a problem in the selection of the processor architecture, the processor whether the user is 64 or 32 bits, the bit returns to %PROCESSOR_ARCHITECTURE% take several values

```
λ echo %PROCESSOR_ARCHITECTURE%
AMD64
λ echo %PROCESSOR_ARCHITECTURE%
IA64
λ echo %PROCESSOR_ARCHITECTURE%
x64
```

http://superuser.com/questions/305901/possible-values-of-processor-architecture

Now with %PROCESSOR_ARCHITECTURE:~-2% this returns :

```
λ echo %PROCESSOR_ARCHITECTURE%
AMD64
λ echo %PROCESSOR_ARCHITECTURE:~-2%
64
λ echo %PROCESSOR_ARCHITECTURE%
IA64
λ echo %PROCESSOR_ARCHITECTURE:~-2%
64
λ echo %PROCESSOR_ARCHITECTURE%
x64
λ echo %PROCESSOR_ARCHITECTURE:~-2%
64
```
