### PR TITLE
Fix 7-zip detection.

### DIFF
--- a/scripts/utils.ps1
+++ b/scripts/utils.ps1
@@ -9,7 +9,7 @@ function Ensure-Exists ($path) {
 function Ensure-Executable ($command) {
     try { Get-Command $command -ErrorAction Stop > $null }
     catch {
-        if( ($command -eq "7z") -and (Ensure-Exists "$env:programfiles\7-zip\7z.exe") ){
+        if( ($command -eq "7z") -and (Test-Path "$env:programfiles\7-zip\7z.exe") ){
             set-alias -Name "7z" -Value "$env:programfiles\7-zip\7z.exe" -Scope script
         } else {
             Write-Error "Missing $command! Ensure it is installed and on in the PATH"


### PR DESCRIPTION
On my system, Ensure-Exist doesn't work. It works if I remove the "> null" in ensure Ensure-Exist method, but then it displays a True in the console.
