### PR TITLE
Revert "Start in the HOME folder."

### DIFF
--- a/config/ConEmu.xml
+++ b/config/ConEmu.xml
@@ -488,7 +488,7 @@
 						<key name="Task1" modified="2014-01-21 18:36:36" build="131215">
 					<value name="Name" type="string" data="{cmd}"/>
 					<value name="GuiArgs" type="string" data=" /icon &quot;%CMDER_ROOT%\cmder.exe&quot;"/>
-					<value name="Cmd1" type="string" data="cmd /k &quot;%ConEmuDir%\..\init.bat&quot;  -new_console:d:%HOME%"/>
+					<value name="Cmd1" type="string" data="cmd /k &quot;%ConEmuDir%\..\init.bat&quot;  -new_console:d:%USERPROFILE%"/>
 					<value name="Active" type="dword" data="00000000"/>
 					<value name="Count" type="dword" data="00000001"/>
 					<value name="Hotkey" type="dword" data="00000000"/>


### PR DESCRIPTION
Reverts bliker/cmder#243

This was a bad idea, it was most likely breaking on anything less than Win8.

Fixes  #252 
