### PR TITLE
Add /reload option to alias.bat

### DIFF
--- a/bin/alias.bat
+++ b/bin/alias.bat
@@ -1,5 +1,6 @@
 @echo off
 if ["%1"] == ["/?"] goto:p_help
+if ["%1"] == ["/reload"] goto:p_reload
 if ["%2"] == [""] echo Insufficient parameters. & goto:p_help
 ::validate alias
 setlocal
@@ -17,6 +18,11 @@ echo %* >> "%CMDER_ROOT%\config\aliases"
 doskey /macrofile="%CMDER_ROOT%\config\aliases"
 echo Alias created
 endlocal
+goto:eof
+
+:p_reload
+doskey /macrofile="%CMDER_ROOT%\config\aliases"
+echo Aliases reloaded
 goto:eof
 
 :p_help


### PR DESCRIPTION
Add a quick way to reload the aliases file using:
  alias /reload

This is useful when you edit the aliases file directly and need to refresh the current shell.
