### PR TITLE
Add make launcher run ConEmu64 on 64-bit Windows

### DIFF
--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -100,7 +100,18 @@ void StartCmder(std::wstring path, bool is_single_mode)
 
 	PathCombine(icoPath, exeDir, L"icons\\cmder.ico");
 	PathCombine(cfgPath, exeDir, L"config\\ConEmu.xml");
-	PathCombine(conEmuPath, exeDir, L"vendor\\conemu-maximus5\\ConEmu.exe");
+
+	SYSTEM_INFO sysInfo;
+	GetNativeSystemInfo(&sysInfo);
+
+	if (sysInfo.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64)
+	{
+		PathCombine(conEmuPath, exeDir, L"vendor\\conemu-maximus5\\ConEmu64.exe");
+	}
+	else
+	{
+		PathCombine(conEmuPath, exeDir, L"vendor\\conemu-maximus5\\ConEmu.exe");
+	}
 
 	if (is_single_mode) 
 	{


### PR DESCRIPTION
This implements #191 for the launcher.
It will run ConEmu64 on 64-bit Windows and ConEmu on 32-bit Windows.