### PR TITLE
Update README.md with link to Visual C++ 2015 Redistr 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Cmder is a **software package** created out of pure frustration over absence of 
 The main advantage of Cmder is portability. It is designed to be totally self-contained with no external dependencies, that is makes it great for **USB Sticks** or **Dropbox**. So you can carry your console, aliases and binaries (like wget, curl and git) with you anywhere.
 
 ## Installation
-
+0. Make sure you have Visual C++ Redistributable 2015 installed. If not, download it here: https://www.microsoft.com/en-US/download/details.aspx?id=46881 (RC version right now, will update link to release when it will be available)
 1. Download the latest release
 2. Extract
 3. (optional) Place your own executable files into the `bin` folder to be injected into your PATH.


### PR DESCRIPTION
Make sure that people will install Visual C++ 2015 Redistributable libraries before everything.

Btw, doesnt this dependency kill all the "portable" thing?