### PR TITLE
added Prerequisites information for C++ Redistributable

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ Cmder is a **software package** created out of pure frustration over absence of 
 
 The main advantage of Cmder is portability. It is designed to be totally self-contained with no external dependencies, that is makes it great for **USB Sticks** or **Dropbox**. So you can carry your console, aliases and binaries (like wget, curl and git) with you anywhere.
 
+## Prerequisites
+
+Visual Studio Installation 2013/2015 or C++ Redistributable package (2013/2015)
+
+1. VS 2015 C++ Redistributable (Version >= 1.2) https://www.microsoft.com/en-US/download/details.aspx?id=46881
+2. VS 2013 C++ Redistributable (Version < 1.2)  https://www.microsoft.com/en-US/download/details.aspx?id=40784
+
+
 ## Installation
 
 1. Download the latest release


### PR DESCRIPTION
Hi,

had an issue with cmder complaining about missing api-ms-win-crt-runtime-l1-1-0.dll on my PC (WIN7 / VS 2013 Community Edition). This is related to VS 2015 update with version 1.2 as neither VS 2015 nor C++ 2015 redistributable was installed.