### PR TITLE
Check for a user init script.

### DIFF
--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -60,4 +60,9 @@
     )
 )
 
+:: Call user-init script, if any
+@if defined CMDER_USER_INIT (
+  @if exist "%CMDER_USER_INIT%" call "%CMDER_USER_INIT%"
+)
+
 :: @call "%CMDER_ROOT%/bin/agent.cmd"


### PR DESCRIPTION
Allow the user to further customize their shell environment without having to touch files in the vendor directory.

After the usual setup in init.bat, check if there is a CMDER_USER_INIT variable defined. If found, call the bat file specified.