### PR TITLE
Fixed: 'Enable-GitColors is Obsolete...' warning

### DIFF
--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -40,7 +40,6 @@ function global:prompt {
 
 # Load special features come from posh-git
 if ($gitStatus) {
-    Enable-GitColors
     Start-SshAgent -Quiet
 }
 


### PR DESCRIPTION
[Fixes] #568 WARNING: Enable-GitColors is Obsolete and will be removed in a future version of posh-git.