### PR TITLE
Revert "Run PowerShell as default"

### DIFF
--- a/config/ConEmu.xml
+++ b/config/ConEmu.xml
@@ -72,7 +72,7 @@
 			<value name="StartType" type="hex" data="02"/>
 			<value name="CmdLine" type="string" data=""/>
 			<value name="StartTasksFile" type="string" data=""/>
-			<value name="StartTasksName" type="string" data="{PowerShell}"/>
+			<value name="StartTasksName" type="string" data="{cmd}"/>
 			<value name="StartFarFolders" type="hex" data="00"/>
 			<value name="StartFarEditors" type="hex" data="00"/>
 			<value name="StoreTaskbarkTasks" type="hex" data="00"/>


### PR DESCRIPTION
This reverts commit aaf70a4d9fe8b23797e0fdbeb81c1ebe0405e1da.

Changing defaults for users is always kind of a bad idea. In addition, the PowerShell mode wasn't really ready for prime time and causing more trouble than good. Users can still change the default if they want to, but we should ship the best working mode by default and that is cmd.