### PR TITLE
Use standard path for ConEmu.xml

### DIFF
--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -79,6 +79,19 @@ optpair GetOption()
 	return pair;
 }
 
+bool FileExists(const wchar_t * filePath)
+{
+	HANDLE hFile = CreateFile(filePath, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, 0, NULL);
+
+	if (hFile != INVALID_HANDLE_VALUE)
+	{
+		CloseHandle(hFile);
+		return true;
+	}
+
+	return false;
+}
+
 void StartCmder(std::wstring path, bool is_single_mode)
 {
 #if USE_TASKBAR_API
@@ -87,6 +100,7 @@ void StartCmder(std::wstring path, bool is_single_mode)
 	wchar_t exeDir[MAX_PATH] = { 0 };
 	wchar_t icoPath[MAX_PATH] = { 0 };
 	wchar_t cfgPath[MAX_PATH] = { 0 };
+	wchar_t oldCfgPath[MAX_PATH] = { 0 };
 	wchar_t conEmuPath[MAX_PATH] = { 0 };
 	wchar_t args[MAX_PATH * 2 + 256] = { 0 };
 
@@ -99,16 +113,29 @@ void StartCmder(std::wstring path, bool is_single_mode)
 	PathRemoveFileSpec(exeDir);
 
 	PathCombine(icoPath, exeDir, L"icons\\cmder.ico");
-	PathCombine(cfgPath, exeDir, L"config\\ConEmu.xml");
+	PathCombine(oldCfgPath, exeDir, L"config\\ConEmu.xml");
+	PathCombine(cfgPath, exeDir, L"vendor\\conemu-maximus5\\ConEmu.xml");
 	PathCombine(conEmuPath, exeDir, L"vendor\\conemu-maximus5\\ConEmu.exe");
+
+	if (FileExists(oldCfgPath) && !FileExists(cfgPath))
+	{
+		if (!CopyFile(oldCfgPath, cfgPath, FALSE))
+		{
+			MessageBox(NULL,
+				(GetLastError() == ERROR_ACCESS_DENIED)
+				? L"Failed to copy ConEmu.xml file to new location! Restart cmder as administrator."
+				: L"Failed to copy ConEmu.xml file to new location!", MB_TITLE, MB_ICONSTOP);
+			exit(1);
+		}
+	}
 
 	if (is_single_mode) 
 	{
-		swprintf_s(args, L"/single /Icon \"%s\" /Title Cmder /LoadCfgFile \"%s\"", icoPath, cfgPath);
+		swprintf_s(args, L"/single /Icon \"%s\" /Title Cmder", icoPath);
 	}
 	else 
 	{
-		swprintf_s(args, L"/Icon \"%s\" /Title Cmder /LoadCfgFile \"%s\"", icoPath, cfgPath);
+		swprintf_s(args, L"/Icon \"%s\" /Title Cmder", icoPath);
 	}
 
 	SetEnvironmentVariable(L"CMDER_ROOT", exeDir);

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -47,7 +47,10 @@ Param(
     [string]$launcher = "..\launcher",
 
     # Include git with the package build
-    [switch]$Full
+    [switch]$Full,
+
+    # config folder location
+    [string]$config = "..\config"
 )
 
 . "$PSScriptRoot\utils.ps1"
@@ -60,6 +63,16 @@ $sources = Get-Content $sourcesPath | Out-String | Convertfrom-Json
 Ensure-Exists $sourcesPath
 Ensure-Executable "7z"
 New-Item -Type Directory -Path (Join-Path $saveTo "/tmp/") -ErrorAction SilentlyContinue >$null
+
+# Preserve modified (by user) ConEmu setting file
+if ($config -ne "") {
+    $ConEmuXml = Join-Path $saveTo "conemu-maximus5\ConEmu.xml"
+    if (Test-Path $ConEmuXml -pathType leaf) {
+        $ConEmuXmlSave = Join-Path $config "ConEmu.xml"
+        Write-Verbose "Backup '$ConEmuXml' to '$ConEmuXmlSave'"
+        Copy-Item $ConEmuXml $ConEmuXmlSave
+    } else { $ConEmuXml = "" }
+} else { $ConEmuXml = "" }
 
 foreach ($s in $sources) {
     if($Full -eq $false -and $s.name -eq "msysgit"){
@@ -81,6 +94,12 @@ foreach ($s in $sources) {
     }
     # Write current version to .cmderver file, for later.
     "$($s.version)" | Out-File "$($s.name)/.cmderver"
+}
+
+# Restore user configuration
+if ($ConEmuXml -ne "") {
+    Write-Verbose "Restore '$ConEmuXmlSave' to '$ConEmuXml'"
+    Copy-Item $ConEmuXmlSave $ConEmuXml
 }
 
 Pop-Location


### PR DESCRIPTION
Placing xml file in the unusual location restricts or limits users from
* pin cmder to TaskBar;
* using "ConEmu here" feature;
* using "DefTerm" feature.

Details are here: https://github.com/Maximus5/ConEmu/issues/277