### PR TITLE
Add a user startup file which can be modified

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ All aliases will be saved in `/config/aliases` file
 
 To start SSH agent simply call `start-ssh-agent`, which is in the `vendor/git-for-windows/cmd` folder.
 
-If you want to run SSH agent on startup, uncomment the line in `/vendor/init.bat`so it says `@call "%GIT_INSTALL_ROOT%/cmd/start-ssh-agent.cmd"`.
+If you want to run SSH agent on startup, include the line `@call "%GIT_INSTALL_ROOT%/cmd/start-ssh-agent.cmd"` in `/config/user-startup.bat` (usually just uncomment it).
 
 ## Todo
 

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -2,6 +2,9 @@
 :: Sets some nice defaults
 :: Created as part of cmder project
 
+:: !!! THIS FILE IS OVERWRITTEN WHEN CMDER IS UPDATED
+:: !!! Use "%CMDER_ROOT%\config\user-startup.cmd" to add your own startup commands
+
 :: Find root dir
 @if not defined CMDER_ROOT (
     for /f "delims=" %%i in ("%ConEmuDir%\..\..") do @set CMDER_ROOT=%%~fi
@@ -60,4 +63,17 @@
     )
 )
 
-:: @call "%GIT_INSTALL_ROOT%/cmd/start-ssh-agent.cmd"
+@if exist "%CMDER_ROOT%\config\user-startup.cmd" (
+    @rem create this file and place your own command in there
+    call "%CMDER_ROOT%\config\user-startup.cmd"
+) else (
+    @echo Creating user startup file: "%CMDER_ROOT%\config\user-startup.cmd"
+    (
+    @echo :: use this file to run your own startup commands 
+    @echo :: use @ in front of the command to prevent printing the command
+    @echo. 
+    @echo :: @call "%GIT_INSTALL_ROOT%/cmd/start-ssh-agent.cmd
+    @echo :: @set PATH=%%CMDER_ROOT%%\vendor\whatever;%%PATH%%
+    @echo. 
+    ) > "%CMDER_ROOT%\config\user-startup.cmd"
+)


### PR DESCRIPTION
Up to now, init.bat would be overwritten when a user updated
Cmder. The new mechanism will create a new (mostly empty) file
for the user to enter commands which will then be executed on
each following startup.

Closes: #608