### PR TITLE
If user has his own powershell profile, use it

### DIFF
--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -50,3 +50,7 @@ if (Test-Path Env:\CMDER_START) {
 } elseif ($Env:CMDER_ROOT -and $Env:CMDER_ROOT.StartsWith($pwd)) {
     Set-Location -Path $Env:USERPROFILE
 }
+
+if (Test-Path $PROFILE) {
+    . $PROFILE
+}


### PR DESCRIPTION
If user has his own `$PROFILE`, cmder should launch it after loading all its settings.

This allows user to set default directory/create new functions or aliases/etc. quite easily and have them available in both cmder and traditional powershell window.