### PR TITLE
Revert 8b8f98c

### DIFF
--- a/scripts/pack.ps1
+++ b/scripts/pack.ps1
@@ -46,7 +46,6 @@ $targets = @{
 }
 
 Delete-Existing "..\Version*"
-Cleanup-Git
 
 $version = Invoke-Expression "git describe --abbrev=0 --tags"
 (New-Item -ItemType file "$cmderRoot\Version $version") | Out-Null

--- a/scripts/utils.ps1
+++ b/scripts/utils.ps1
@@ -61,11 +61,6 @@ function Digest-MD5 ($path) {
     return Invoke-Expression "md5sum $path"
 }
 
-function Cleanup-Git () {
-    $gitdir = '../vendor/msysgit/libexec/git-core/'
-    Get-Childitem $gitdir -Exclude git.exe | Where-Object{!($_.PSIsContainer)} | Foreach-Object { Remove-Item $_.FullName }
-}
-
 function Register-Cmder(){
     [CmdletBinding()]
     Param


### PR DESCRIPTION
Breaks Git: #503 #521, because `git <command>` actually uses `git-<command>`.