### PR TITLE
Updated link for msysgit

### DIFF
--- a/vendor/sources.json
+++ b/vendor/sources.json
@@ -1,8 +1,8 @@
 [
     {
-        "name": "msysgit",
-        "version": "1.9.5-preview20150319",
-        "url": "https://github.com/msysgit/msysgit/releases/download/Git-1.9.5-preview20150319/PortableGit-1.9.5-preview20150319.7z"
+        "name": "git",
+        "version": "2.5.2.windows.2",
+        "url": "https://github.com/git-for-windows/git/releases/download/v2.5.2.windows.2/PortableGit-2.5.2.2-32-bit.7z.exe"
     },
     {
         "name": "clink",


### PR DESCRIPTION
Git for Windows 1.x is deprecated, superseded by Git for Windows 2.x. as per https://github.com/msysgit/msysgit/releases