### PR TITLE
Fix init.bat generation

### DIFF
--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -72,7 +72,7 @@
     @echo :: use this file to run your own startup commands 
     @echo :: use @ in front of the command to prevent printing the command
     @echo. 
-    @echo :: @call "%GIT_INSTALL_ROOT%/cmd/start-ssh-agent.cmd
+    @echo :: @call "%%GIT_INSTALL_ROOT%%/cmd/start-ssh-agent.cmd
     @echo :: @set PATH=%%CMDER_ROOT%%\vendor\whatever;%%PATH%%
     @echo. 
     ) > "%CMDER_ROOT%\config\user-startup.cmd"


### PR DESCRIPTION
The code which generated the init.bat did not escape the env var and so the content of the current env var was hardcoded in init-bat.