### PR TITLE
Add user startup file for powershell

### DIFF
--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -63,3 +63,13 @@ if (Test-Path Env:\CMDER_START) {
 
 # Enhance Path
 $env:Path = "$Env:CMDER_ROOT\bin;$env:Path;$Env:CMDER_ROOT"
+
+
+$CmderUserProfilePath = Join-Path $env:CMDER_ROOT "config/user-profile.ps1"
+if(Test-Path $CmderUserProfilePath) {
+    # Create this file and place your own command in there.
+    Invoke-Expression $CmderUserProfilePath
+} else {
+    Write-Host "Creating user startup file: $CmderUserProfilePath"
+    "# Use this file to run your own startup commands" | Out-File $CmderUserProfilePath
+}


### PR DESCRIPTION
The cmd version has a customizable file but powershell was missing one.