### PR TITLE
Fixed problem with Invoke-Expression

### DIFF
--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -1,4 +1,4 @@
-# Init Script for PowerShell
+﻿# Init Script for PowerShell
 # Created as part of cmder project
 
 # !!! THIS FILE IS OVERWRITTEN WHEN CMDER IS UPDATED

--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -74,7 +74,7 @@ $env:Path = "$Env:CMDER_ROOT\bin;$env:Path;$Env:CMDER_ROOT"
 $CmderUserProfilePath = Join-Path $env:CMDER_ROOT "config/user-profile.ps1"
 if(Test-Path $CmderUserProfilePath) {
     # Create this file and place your own command in there.
-    Invoke-Expression $CmderUserProfilePath
+    . "$CmderUserProfilePath"
 } else {
     Write-Host "Creating user startup file: $CmderUserProfilePath"
     "# Use this file to run your own startup commands" | Out-File $CmderUserProfilePath


### PR DESCRIPTION
Invoke-Expression has a problem with spaces in path names(oops), this fixes that issue.
Also, the file or atleast the lambda needs to be encoded in UTF-8-BOM else it won't show properly.