### PR TITLE
Added check for git install path in init.bat.

### DIFF
--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -37,6 +37,8 @@
     set "GIT_INSTALL_ROOT=%ProgramFiles%\Git"
 ) else if exist "%ProgramFiles(x86)%\Git" (
     set "GIT_INSTALL_ROOT=%ProgramFiles(x86)%\Git"
+) else if exist "%USERPROFILE%\AppData\Local\Programs\Git" (
+    set "GIT_INSTALL_ROOT=%USERPROFILE%\AppData\Local\Programs\Git"
 ) else if exist "%CMDER_ROOT%\vendor\git-for-windows" (
     set "GIT_INSTALL_ROOT=%CMDER_ROOT%\vendor\git-for-windows"
 )


### PR DESCRIPTION
Added check for %USERPROFILE%\AppData\Local\Programs\Git path in init.bat.  Installing from https://git-scm.com/download/win seems to put git in this directory.

Long story short, I was having issues doing npm installs pointing to cmder's packaged version of git-for-windows, but the version from https://git-scm.com/download/win worked just fine.  This change defaults to using an installed version of git outside of cmder's packaged version.