### PR TITLE
Fix: don't garble the input line for long lines in git projects

### DIFF
--- a/vendor/cmder.lua
+++ b/vendor/cmder.lua
@@ -142,7 +142,7 @@ end
  -- @return {bool}
 ---
 function get_git_status()
-    return os.execute("git diff --quiet --ignore-submodules HEAD 2>nul")
+    return io.popen("git diff --quiet --ignore-submodules HEAD 2>nul")
 end
 
 function git_prompt_filter()


### PR DESCRIPTION
If having a long line of input in histroy, which went on into the
second row and using <up> to get back to it, you got the effect
that the input was split over three lines: "text, empty, text",
but using the arrows do move to the front of the first line was
moving the cursor in the second (empty) row. You could change
the text, but you needed to do it "in the dark".  No idea why
s/os.execute/is.popen/ fixes this, but it does.

Partly adresses https://github.com/cmderdev/cmder/issues/749