### PR TITLE
Fix vendor/init.bat when the PATH contains spaces.

### DIFF
--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -51,7 +51,7 @@
 )
 
 :: Enhance Path
-@set PATH=%CMDER_ROOT%\bin;%PATH%;%CMDER_ROOT%\
+@set "PATH=%CMDER_ROOT%\bin;%PATH%;%CMDER_ROOT%\"
 
 
 :: make sure we have an example file


### PR DESCRIPTION
Fixes #727 #728