### PR TITLE
Make "cmder here" work again

### DIFF
--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -63,10 +63,12 @@ optpair GetOption()
 
 	if (argc == 1)
 	{
+		// no commandline argument...
 		pair = optpair(L"/START", L"");
 	}
 	else if (argc == 2 && argv[1][0] != L'/')
 	{
+		// only a single argument: this should be a path...
 		pair = optpair(L"/START", argv[1]);
 	}
 	else
@@ -152,20 +154,16 @@ void StartCmder(std::wstring path, bool is_single_mode)
 	}
 
 		SetEnvironmentVariable(L"CMDER_ROOT", exeDir);
-		//SetEnvironmentVariable(L"CMDER_START", path.c_str());
+		if (!streqi(path.c_str(), L""))
+		{
+			SetEnvironmentVariable(L"CMDER_START", path.c_str());
+		}
 
 		// Send out the Settings Changed message - Once using ANSII...
 		//SendMessageTimeout(HWND_BROADCAST, WM_SETTINGCHANGE, 0, (LPARAM)"Environment", SMTO_ABORTIFHUNG, 5000, NULL);
 
 		// ...and once using UniCode (because Windows 8 likes it that way).
 		//SendMessageTimeout(HWND_BROADCAST, WM_SETTINGCHANGE, 0, (LPARAM) L"Environment", SMTO_ABORTIFHUNG, 5000, NULL);
-
-		HKEY cmderStartRegistryKey;
-		if (RegCreateKeyEx(HKEY_CURRENT_USER, L"Software\\cmder", 0, NULL, 0, KEY_ALL_ACCESS, NULL, &cmderStartRegistryKey, 0) == ERROR_SUCCESS)
-		{
-			RegSetValueEx(cmderStartRegistryKey, L"CMDER_START", 0, REG_SZ, (const BYTE*) path.c_str(), path.size() * 2);
-			RegCloseKey(cmderStartRegistryKey);
-		}
 
 	STARTUPINFO si = { 0 };
 	si.cb = sizeof(STARTUPINFO);

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -58,7 +58,7 @@
 @if not exist "%CMDER_ROOT%\config\aliases" (
     echo Creating intial aliases in %CMDER_ROOT%\config\aliases
     copy "%CMDER_ROOT%\vendor\aliases.example" "%CMDER_ROOT%\config\aliases" > null
-) 
+)
 
 :: Add aliases
 @doskey /macrofile="%CMDER_ROOT%\config\aliases"
@@ -76,12 +76,10 @@
 :: Set home path
 @if not defined HOME set HOME=%USERPROFILE%
 
+:: This is either a env variable set by the user or the result of
+:: cmder.exe setting this variable due to a commandline argument or a "cmder here"
 @if defined CMDER_START (
     @cd /d "%CMDER_START%"
-) else (
-    @if "%CD%\" == "%CMDER_ROOT%\" (
-        @cd /d "%HOME%"
-    )
 )
 
 @if exist "%CMDER_ROOT%\config\user-profile.cmd" (

--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -32,7 +32,7 @@ try {
     # $env:Path += $(";" + $env:CMDER_ROOT + "\vendor\git-for-windows\usr\bin")
     # set-alias -name "vi" -value "vim"
     # # I think the below is safer.
-    
+
     new-alias -name "vim" -value $($ENV:CMDER_ROOT + "\vendor\git-for-windows\usr\bin\vim.exe")
     new-alias -name "vi" -value vim
 }
@@ -82,33 +82,14 @@ if ($gitStatus) {
 }
 
 # Move to the wanted location
-$cmderStartKey = 'HKCU:\Software\cmder'
-$cmderStartSubKey = 'CMDER_START'
-
-$cmderStart = (Get-Item -Path $cmderStartKey -ErrorAction SilentlyContinue)
-
-if ( $cmderStart ) {
-    $cmderStart = $cmderStart.GetValue($cmderStartSubKey)
-    $cmderStart = ($cmderStart).Trim('"').Trim("'")
-    if ( $cmderStart.EndsWith(':') ) {
-        $cmderStart += '\'
-    }
-
-    if ( ( Get-Item $cmderStart -Force ) -is [System.IO.FileInfo] ) {
-        $cmderStart = Split-Path $cmderStart
-    }
-
-    Set-Location -Path "${cmderStart}"
-
-    Set-ItemProperty -Path $cmderStartKey -Name $cmderStartSubKey -Value $null
-} else {
-    Set-Location -Path "${env:HOME}"
+# This is either a env variable set by the user or the result of
+# cmder.exe setting this variable due to a commandline argument or a "cmder here"
+if ( $ENV:CMDER_START ) {
+    Set-Location -Path "$ENV:CMDER_START"
 }
-
 
 # Enhance Path
 $env:Path = "$Env:CMDER_ROOT\bin;$env:Path;$Env:CMDER_ROOT"
-
 
 $CmderUserProfilePath = Join-Path $env:CMDER_ROOT "config\user-profile.ps1"
 if(Test-Path $CmderUserProfilePath) {


### PR DESCRIPTION
The new system works by setting "CMDER_START" if a cmder.exe gets a
startup path. The rest is then implemented in the profile.ps1 and init.bat.
The new system works as follows:

1.If a startup path is given, cmder.exe sets this as `CMDER_START` and the
  startup scripts change to that directory.
2.If the usere sets a `CMDER_START` environment variable and this is not
  overwritten by cmder.exe, this variable is taken as the startup
  directory by the startup scripts.
3.If not such path is give, the conemu startup dirs is the winner, as the
  startup scripts don't change anything.

Closes: https://github.com/cmderdev/cmder/issues/772