### PR TITLE
Fixed checkGit() in case of submodules

### DIFF
--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -15,7 +15,7 @@ try {
 }
 
 function checkGit($Path) {
-    if (Test-Path -Path (Join-Path $Path '.git/') ) {
+    if (Test-Path -Path (Join-Path $Path '.git') ) {
         Write-VcsStatus
         return
     }


### PR DESCRIPTION
Since Git 1.7.8, submodules don't contain a .git/ folder anymore.
Instead, the submodule directory is populated with a .git text file
which contains a git-dir: /path/to/superproject/git_dir/modules/name.

See,
https://github.com/git/git/blob/master/Documentation/RelNotes/1.7.8.txt#L109-L114