### PR TITLE
Enhanced alias.bat to allow file storage path

### DIFF
--- a/bin/alias.bat
+++ b/bin/alias.bat
@@ -1,64 +1,131 @@
 @echo off
 
-set ALIASES=%CMDER_ROOT%\config\aliases
-setlocal
-:: handle quotes within command definition, e.g. quoted long file names
-set _x="%*"
-set _x=%_x:"=%
+
+if "%aliases%" == "" (
+  set ALIASES=%CMDER_ROOT%\config\user-aliases.cmd
+)
+
+setlocal enabledelayedexpansion
+
+if "%~1" == "" echo Use /? for help & echo. & goto :p_show
 
 :: check command usage
-if ["%_x%"] == [""] echo Use /? for help & echo. & goto :p_show
-if ["%1"] == ["/?"] goto:p_help
-if ["%1"] == ["/reload"] goto:p_reload
-:: /d flag for delete existing alias
-if ["%1"] == ["/d"] goto:p_del %*
-:: if arg is an existing alias, display it
-if ["%2"] == [""] (
-  doskey /macros | findstr /b %1= && goto:eof
-  echo Insufficient parameters. & goto:p_help
+
+rem #region parseargument
+goto parseargument
+
+:do_shift
+  shift
+
+:parseargument
+  set currentarg=%~1
+
+  if /i "%currentarg%" equ "/f" (
+    set aliases=%~2
+    shift
+    goto :do_shift
+  ) else if /i "%currentarg%" == "/reload" (
+    goto :p_reload
+  ) else if "%currentarg%" equ "/?" (
+    goto :p_help
+  ) else if /i "%currentarg%" equ "/d" (
+    if "%~2" neq "" (
+      if "%~3" equ "" (
+        :: /d flag for delete existing alias
+        call :p_del %~2
+        shift
+        goto :eof
+      )
+    )
+  ) else if "%currentarg%" neq "" (
+    if "%~2" equ "" (
+      :: Show the specified alias
+      doskey /macros | findstr /b %currentarg%= && exit /b
+      echo insufficient parameters.
+      goto :p_help
+    ) else (
+      :: handle quotes within command definition, e.g. quoted long file names
+      set _x=%*
+    )
+  )
+rem #endregion parseargument
+
+if "%aliases%" neq "%CMDER_ROOT%\config\user-aliases.cmd" (
+  set _x=!_x:/f %aliases% =!
+
+  if not exist "%aliases%" (
+    echo ;= @echo off>"%aliases%"
+    echo ;= rem Call DOSKEY and use this file as the macrofile>>"%aliases%"
+    echo ;= %%SystemRoot%%\system32\doskey /listsize=1000 /macrofile=%%0%%>>"%aliases%"
+    echo ;= rem In batch mode, jump to the end of the file>>"%aliases%"
+    echo ;= goto:eof>>"%aliases%"
+    echo ;= Add aliases below here>>"%aliases%"
+  )
 )
 
 :: validate alias
-for /f "delims== tokens=1" %%G in ("%_x%") do set alias=%%G
-set _temp=%alias: =%
+for /f "delims== tokens=1,2 usebackq" %%G in (`echo "%_x%"`) do (
+  set alias_name=%%G
+  set alias_value=%%H
+)
 
-if not ["%_temp%"] == ["%alias%"] (
+:: leading quotes added while validating
+set alias_name=%alias_name:~1%
+
+:: trailing quotes added while validating
+set alias_value=%alias_value:~0,-1%
+
+::remove spaces
+set _temp=%alias_name: =%
+
+if not ["%_temp%"] == ["%alias_name%"] (
 	echo Your alias name can not contain a space
 	endlocal
-	goto:eof
+	exit /b
 )
 
 :: replace already defined alias
-findstr /b /v /i "%alias%=" "%ALIASES%" >> "%ALIASES%.tmp"
-echo %* >> "%ALIASES%.tmp" && type "%ALIASES%.tmp" > "%ALIASES%" & @del /f /q "%ALIASES%.tmp"
+findstr /b /v /i "%alias_name%=" "%ALIASES%" >> "%ALIASES%.tmp"
+echo %alias_name%=%alias_value% >> "%ALIASES%.tmp" && type "%ALIASES%.tmp" > "%ALIASES%" & @del /f /q "%ALIASES%.tmp"
 doskey /macrofile="%ALIASES%"
 endlocal
-goto:eof
+exit /b
 
 :p_del
-findstr /b /v /i "%2=" "%ALIASES%" >> "%ALIASES%.tmp"
+set del_alias=%~1
+findstr /b /v /i "%del_alias%=" "%ALIASES%" >> "%ALIASES%.tmp"
 type "%ALIASES%".tmp > "%ALIASES%" & @del /f /q "%ALIASES%.tmp"
+doskey %del_alias%=
 doskey /macrofile=%ALIASES%
 goto:eof
 
 :p_reload
 doskey /macrofile="%ALIASES%"
 echo Aliases reloaded
-goto:eof
+exit /b
 
 :p_show
-type "%ALIASES%" || echo No aliases found at "%ALIASES%"
-goto :eof
+doskey /macros|findstr /v /r "^;=" | sort
+exit /b
 
 :p_help
 echo.Usage:
-echo.	alias [/reload] [/d] [name=full command]
-echo.     /reload  Reload the aliases file
-echo.     /d       Delete an alias (must be followed by the alias name)
+echo. 
+echo.	alias [options] [alias=full command]
+echo. 
+echo.Options:
+echo. 
+echo.     /d [alias]     Delete an [alias].
+echo.     /f [macrofile] Path to the [macrofile] you want to store the new alias in.
+echo.                    Default: %cmder_root%\config\user-aliases.cmd
+echo.     /reload        Reload the aliases file.  Can be used with /f argument.
+echo.                    Default: %cmder_root%\config\user-aliases.cmd
 echo.
-echo.	If alias is called with any parameters, it will display the list of existing aliases.
+echo.	If alias is called with no parameters, it will display the list of existing aliases.
+echo.
 echo.	In the command, you can use the following notations:
 echo.	$* allows the alias to assume all the parameters of the supplied command.
 echo.	$1-$9 Allows you to seperate parameter by number, much like %%1 in batch.
 echo.	$T is the command seperator, allowing you to string several commands together into one alias.
 echo.	For more information, read DOSKEY/?
+exit /b

--- a/vendor/aliases.example
+++ b/vendor/aliases.example
@@ -1,8 +1,0 @@
-e.=explorer .
-gl=git log --oneline --all --graph --decorate  $*
-ls=ls --show-control-chars -F --color $*
-pwd=cd
-clear=cls
-history=cat %CMDER_ROOT%\config\.history
-unalias=alias /d $1
-vi=vim $*

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -59,15 +59,21 @@
 :: Enhance Path
 @set "PATH=%CMDER_ROOT%\bin;%PATH%;%CMDER_ROOT%\"
 
-
 :: make sure we have an example file
-@if not exist "%CMDER_ROOT%\config\aliases" (
-    echo Creating intial aliases in %CMDER_ROOT%\config\aliases
-    copy "%CMDER_ROOT%\vendor\aliases.example" "%CMDER_ROOT%\config\aliases" > null
+@set aliases=%CMDER_ROOT%\config\user-aliases.cmd
+@if not exist "%aliases%" (
+    echo Creating intial aliases in "%aliases%"...
+    copy "%CMDER_ROOT%\vendor\user-aliases.cmd.example" "%aliases%"
 )
 
-:: Add aliases
-@doskey /macrofile="%CMDER_ROOT%\config\aliases"
+:: Update old 'aliases' to new self executing 'user-aliases.cmd'
+@if exist "%CMDER_ROOT%\config\aliases" (
+  echo Updating old "%CMDER_ROOT%\config\aliases" to new format...
+  type "%CMDER_ROOT%\config\aliases" >> "%aliases%" && del "%CMDER_ROOT%\config\aliases"
+)
+  
+:: Add aliases to the environment.
+@call "%aliases%"
 
 :: See vendor\git-for-windows\README.portable for why we do this
 :: Basically we need to execute this post-install.bat because we are
@@ -90,9 +96,10 @@
 
 :: Drop *.bat and *.cmd files into "%CMDER_ROOT%\config\profile.d"
 :: to run them at startup.
+
 @if not exist "%CMDER_ROOT%\config\profile.d" (
   mkdir "%CMDER_ROOT%\config\profile.d"
-}
+)
 
 @pushd "%CMDER_ROOT%\config\profile.d"
 for /f "usebackq" %%x in ( `dir /b *.bat *.cmd` ) do (
@@ -100,7 +107,6 @@ for /f "usebackq" %%x in ( `dir /b *.bat *.cmd` ) do (
   @call %%x
 )
 @popd
-
 
 @if exist "%CMDER_ROOT%\config\user-profile.cmd" (
     @rem create this file and place your own command in there

--- a/vendor/user-aliases.cmd.example
+++ b/vendor/user-aliases.cmd.example
@@ -1,0 +1,15 @@
+;= @echo off
+;= rem Call DOSKEY and use this file as the macrofile
+;= %SystemRoot%\system32\doskey /listsize=1000 /macrofile=%0%
+;= rem In batch mode, jump to the end of the file
+;= goto:eof
+;= Add aliases below here
+e.=explorer .
+gl=git log --oneline --all --graph --decorate  $*
+ls=ls --show-control-chars -F --color $*
+pwd=cd
+clear=cls
+history=cat %CMDER_ROOT%\config\.history
+unalias=alias /d $1
+vi=vim $*
+cmderr=cd /d "%CMDER_ROOT%"


### PR DESCRIPTION
This PR changes/enhances bin/alias.bat:

1. bin/alias.bat now has more robust command line parsing.
2. bin/alias.bat now uses config/user-aliases.cmd as the default alias store, this is to make things consistent across all shells.
3. config/user-aliases.cmd is a self executing batch file/doskey macro store.

  ```
  ;= @echo off
  ;= rem Call DOSKEY and use this file as the macrofile
  ;= %SystemRoot%\system32\doskey /listsize=1000 /macrofile=%0%
  ;= rem In batch mode, jump to the end of the file
  ;= goto:eof
  ;= Add aliases below here
  e.=explorer .
  gl=git log --oneline --all --graph --decorate  $*
  ls=ls --show-control-chars -F --color $*
  pwd=cd
  clear=cls
  history=cat %CMDER_ROOT%\config\.history
  unalias=alias /d $1
  vi=vim $*
  ```
4. vendor/init.bat will update existing config/aliases to the new self executing config/user-aliases.cmd format and remove the old file.
5. bin/alias.bat has a new command line argument '/f' that allows specification of the file store for new aliases.
6. bin/alias.bat now displays 'ALL' loaded macros if executed with no arguments.
7. bin/alias.bat deletes aliases from memory and the file store when '/d' is specified.
