### PR TITLE
Revert "Set CMDER_START to homeprofile"

### DIFF
--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -3,7 +3,6 @@
 #include <Shlwapi.h>
 #include "resource.h"
 #include <vector>
-#include <Shlobj.h>
 
 
 #pragma comment(lib, "Shlwapi.lib")
@@ -156,16 +155,7 @@ void StartCmder(std::wstring path, bool is_single_mode)
 	}
 
 	SetEnvironmentVariable(L"CMDER_ROOT", exeDir);
-	if (streqi(path.c_str(), L""))
-	{
-		wchar_t* homeProfile = 0;
-		SHGetKnownFolderPath(FOLDERID_Profile, 0, NULL, &homeProfile);
-		if (!SetEnvironmentVariable(L"CMDER_START", homeProfile)) {
-			MessageBox(NULL, _T("Error trying to set CMDER_START to given path!"), _T("Error"), MB_OK);
-		}
-		CoTaskMemFree(static_cast<void*>(homeProfile));
-	}
-	else
+	if (!streqi(path.c_str(), L""))
 	{
 		if (!SetEnvironmentVariable(L"CMDER_START", path.c_str())) {
 			MessageBox(NULL, _T("Error trying to set CMDER_START to given path!"), _T("Error"), MB_OK);


### PR DESCRIPTION
This PR is more or less to have a easier way to discuss the issue...

This reverts commit 728e83a85bea6ad7b4ddda0b960c443e3ef9f737.

The problem with *always* setting CMDER_START is that this makes the `-new_console:d:%USERPROFILE%` in the conemu task definitions unnecessary, as this is now always overwritten as CMDER_START is set. This also means that a very visible conemu UI for setting the startup dir does not work anymore (try opening a cmder windows when the default task has a `-new_console:d:c:\temp`) which might leave the user puzzled.

So: what is the use case for *always* setting the variable and if that's important: why not set it in the startup scripts after they have checked where to start up?