### PR TITLE
Remove Enable-GitColors from profile.ps1

### DIFF
--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -40,7 +40,6 @@ function global:prompt {
 
 # Load special features come from posh-git
 if ($gitStatus) {
-    Enable-GitColors
     Start-SshAgent -Quiet
 }
 


### PR DESCRIPTION
This is a default in Posh-Git now. It complains about it being obsolete, and it will be removed in future versions of Posh-Git

See https://github.com/cmderdev/cmder/issues/568