### PR TITLE
Fix missing "\" when building dirpath to psmodules

### DIFF
--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -18,7 +18,7 @@ if(!$PSScriptRoot) {
 }
 
 # Add Cmder modules directory to the autoload path.
-$CmderModulePath = Join-path $PSScriptRoot "psmodules/"
+$CmderModulePath = Join-path $PSScriptRoot "\psmodules/"
 
 if( -not $env:PSModulePath.Contains($CmderModulePath) ){
     $env:PSModulePath = $env:PSModulePath.Insert(0, "$CmderModulePath;")


### PR DESCRIPTION
Join-Path won't add "\"'s without the use of a delimeter.  In this case there is no delimiter and as a result the script will fail when it tries to look up $CmderModulePath.