### PR TITLE
Add quotes around all variables

### DIFF
--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -12,7 +12,7 @@ if not defined CMDER_ROOT (
 )
 
 :: Remove trailing '\'
-if "%CMDER_ROOT:~-1%" == "\" SET CMDER_ROOT=%CMDER_ROOT:~0,-1%
+if "%CMDER_ROOT:~-1%" == "\" SET "CMDER_ROOT=%CMDER_ROOT:~0,-1%"
 
 :: Change the prompt style
 :: Mmm tasty lamb
@@ -27,8 +27,8 @@ if "%PROCESSOR_ARCHITECTURE%"=="x86" (
 
 :: Tell the user about the clink config files...
 if not exist "%CMDER_ROOT%\config\settings" (
-    echo Generating clink initial settings in %CMDER_ROOT%\config\settings
-    echo Additional *.lua files in %CMDER_ROOT%\config are loaded on startup.
+    echo Generating clink initial settings in "%CMDER_ROOT%\config\settings"
+    echo Additional *.lua files in "%CMDER_ROOT%\config" are loaded on startup.
 )
 
 :: Run clink
@@ -100,7 +100,7 @@ if not exist "%CMDER_ROOT%\config\profile.d" (
 
 pushd "%CMDER_ROOT%\config\profile.d"
 for /f "usebackq" %%x in ( `dir /b *.bat *.cmd 2^>nul` ) do (
-  REM echo Calling %CMDER_ROOT%\config\profile.d\%%x...
+  REM echo Calling "%CMDER_ROOT%\config\profile.d\%%x"...
   call "%CMDER_ROOT%\config\profile.d\%%x"
 )
 popd
@@ -157,8 +157,8 @@ if exist "%CMDER_ROOT%\config\user-profile.cmd" (
     echo :: use this file to run your own startup commands
     echo :: use  in front of the command to prevent printing the command
     echo.
-    echo :: call "%%GIT_INSTALL_ROOT%%/cmd/start-ssh-agent.cmd
-    echo :: set PATH=%%CMDER_ROOT%%\vendor\whatever;%%PATH%%
+    echo :: call "%%GIT_INSTALL_ROOT%%/cmd/start-ssh-agent.cmd"
+    echo :: set "PATH=%%CMDER_ROOT%%\vendor\whatever;%%PATH%%"
     echo.
     ) > "%CMDER_ROOT%\config\user-profile.cmd"
 )


### PR DESCRIPTION
This should prevent errors like
https://github.com/cmderdev/cmder/issues/935
https://github.com/cmderdev/cmder/issues/937

I've no idea why this happens, but it shouldn't hurt anyway...