### PR TITLE
Custom prompt hooks protected from later overwriting

### DIFF
--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -157,6 +157,7 @@ Set-Item -Path function:\PostPrompt  -Value $PostPrompt  -Options Constant
 
 [ScriptBlock]$Prompt = {
     $realLASTEXITCODE = $LASTEXITCODE
+    $host.UI.RawUI.WindowTitle = Split-Path $pwd.ProviderPath -Leaf
     PrePrompt | Microsoft.PowerShell.Utility\Write-Host -NoNewline
     CmderPrompt
     Microsoft.PowerShell.Utility\Write-Host "`nλ " -NoNewLine -ForegroundColor "DarkGray"

--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -65,11 +65,6 @@ function checkGit($Path) {
     }
 }
 
-# Load special features come from posh-git
-if ($gitStatus) {
-    Start-SshAgent -Quiet
-}
-
 # Move to the wanted location
 # This is either a env variable set by the user or the result of
 # cmder.exe setting this variable due to a commandline argument or a "cmder here"

--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -49,9 +49,14 @@ try {
 $gitLoaded = $false
 function Import-Git($Loaded){
     if($Loaded) { return }
-    if(-not (Get-Module -Name Posh-Git -ListAvailable) ) {
+    $GitModule = Get-Module -Name Posh-Git -ListAvailable
+    if($GitModule | select version | where version -le ([version]"0.6.1.20160330")){
+        Import-Module Posh-Git > $null
+    }
+    if(-not ($GitModule) ) {
         Write-Warning "Missing git support, install posh-git with 'Install-Module posh-git' and restart cmder."
     }
+    # Make sure we only run once by alawys returning true
     return $true
 }
 

--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -46,16 +46,18 @@ try {
     $env:Path += $(";" + $env:CMDER_ROOT + "\vendor\git-for-windows\bin")
 }
 
-try {
-    Import-Module -Name "posh-git" -ErrorAction Stop >$null
-    $gitStatus = $true
-} catch {
-    Write-Warning "Missing git support, install posh-git with 'Install-Module posh-git' and restart cmder."
-    $gitStatus = $false
+$gitLoaded = $false
+function Import-Git($Loaded){
+    if($Loaded) { return }
+    if(-not (Get-Module -Name Posh-Git -ListAvailable) ) {
+        Write-Warning "Missing git support, install posh-git with 'Install-Module posh-git' and restart cmder."
+    }
+    return $true
 }
 
 function checkGit($Path) {
     if (Test-Path -Path (Join-Path $Path '.git') ) {
+        $gitLoaded = Import-Git $gitLoaded
         Write-VcsStatus
         return
     }
@@ -103,9 +105,7 @@ popd
 [ScriptBlock]$CmderPrompt = {
     $Host.UI.RawUI.ForegroundColor = "White"
     Microsoft.PowerShell.Utility\Write-Host $pwd.ProviderPath -NoNewLine -ForegroundColor Green
-    if($gitStatus){
-        checkGit($pwd.ProviderPath)
-    }
+    checkGit($pwd.ProviderPath)
 }
 
 $CmderUserProfilePath = Join-Path $env:CMDER_ROOT "config\user-profile.ps1"

--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -155,9 +155,14 @@ Set-Item -Path function:\PrePrompt   -Value $PrePrompt   -Options Constant
 Set-Item -Path function:\CmderPrompt -Value $CmderPrompt -Options Constant
 Set-Item -Path function:\PostPrompt  -Value $PostPrompt  -Options Constant
 
+<#
+This scriptblock runs every time the prompt is returned.
+Explicitly use functions from MS namespace to protect from being overridden in the user session.
+Custom prompt functions are loaded in as constants to get the same behaviour
+#>
 [ScriptBlock]$Prompt = {
     $realLASTEXITCODE = $LASTEXITCODE
-    $host.UI.RawUI.WindowTitle = Split-Path $pwd.ProviderPath -Leaf
+    $host.UI.RawUI.WindowTitle = Microsoft.PowerShell.Management\Split-Path $pwd.ProviderPath -Leaf
     PrePrompt | Microsoft.PowerShell.Utility\Write-Host -NoNewline
     CmderPrompt
     Microsoft.PowerShell.Utility\Write-Host "`nλ " -NoNewLine -ForegroundColor "DarkGray"
@@ -166,5 +171,6 @@ Set-Item -Path function:\PostPrompt  -Value $PostPrompt  -Options Constant
     return " "
 }
 
+# Functions can be made constant only at creation time
 # ReadOnly at least requires `-force` to be overwritten
 Set-Item -Path function:\prompt  -Value $Prompt  -Options ReadOnly


### PR DESCRIPTION
In reference to issue #950 about PR #951 I have the following suggestion.

@centur I like your suggestion, I'm just uneasy out by the idea of running any function that is called `User-PrePrompt`, `User-Prompt`, `User-PostPrompt` as the prompt reloads. After trying that out I wasn't enthused to find the following idea has some fun effects.

`function Write-Host {'Hello Boys, I'm Back'}`

So with that, I propose: 
- Add a pre and post function hook around the Cmder prompt.
- Specify the cmder prompt as a function that could be replaced by a user.
- Write a friendly message when the user profile template is created.
- Create the user profile with cmder prompt hooks ready to use.

Core functions have been explicitly called from their namespace like Microsoft.PowerShell.Utility\Write-Host to try and prevent clobbering with later defined functions.

User supplied functions are variables in as script blocks, created as the session runs the profile script. By creating them as constants these function names cannot be re-declared for the duration of the process.

Since the prompt function already exists by this time, set the readOnly flag so to re-declare the prompt requires the use of -force.

It is hoped these changes limit what could be the risk of any script redefining functions that are called automatically without user intent or input. 