### PR TITLE
cmd: change the prompt in lua

### DIFF
--- a/vendor/clink.lua
+++ b/vendor/clink.lua
@@ -12,6 +12,21 @@ dofile(clink_lua_file)
 
 -- now add our own things...
 
+---
+ -- Setting the prompt in clink means that commands which rewrite the prompt do
+ -- not destroy our own prompt. It also means that started cmds (or batch files
+ -- which echo) don't get the ugly '{lamb}' shown.
+---
+function set_prompt_filter()
+    -- orig: $E[1;32;40m$P$S{git}{hg}$S$_$E[1;30;40m{lamb}$S$E[0m
+    -- color codes: "\x1b[1;37;40m"
+    cwd = clink.get_cwd()
+    prompt = "\x1b[1;32;40m{cwd} {git}{hg} \n\x1b[1;30;40m{lamb} \x1b[0m"
+    new_value = string.gsub(prompt, "{cwd}", cwd)
+    clink.prompt.value = new_value
+end
+
+
 function lambda_prompt_filter()
     clink.prompt.value = string.gsub(clink.prompt.value, "{lamb}", "λ")
 end
@@ -230,6 +245,8 @@ function git_prompt_filter()
     return false
 end
 
+-- insert the set_prompt at the very beginning so that it runs first
+clink.prompt.register_filter(set_prompt_filter, 1)
 clink.prompt.register_filter(lambda_prompt_filter, 40)
 clink.prompt.register_filter(hg_prompt_filter, 50)
 clink.prompt.register_filter(git_prompt_filter, 50)

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -17,10 +17,6 @@ if not defined CMDER_ROOT (
 :: Remove trailing '\'
 if "%CMDER_ROOT:~-1%" == "\" SET "CMDER_ROOT=%CMDER_ROOT:~0,-1%"
 
-:: Change the prompt style
-:: Mmm tasty lamb
-prompt $E[1;32;40m$P$S{git}{hg}$S$_$E[1;30;40m{lamb}$S$E[0m
-
 :: Pick right version of clink
 if "%PROCESSOR_ARCHITECTURE%"=="x86" (
     set architecture=86


### PR DESCRIPTION
This keeps the PROMPT variable as is and changes the prompt to the cmder style
in the clink code.

This has two advantages:

* opening a cmd in a cmder session will now show the old prompt code instead of
  a ugly raw prompt without the replacements. This led to ugly output when a
  batch file echoed their content (e.g `conda build recipe/`).

* when a command rewrites the prompt (e.g. an activate in a virtualenv), these
  commands sometime simple overwrite the PROMPT so that the cmder enhancements
  were not anymore in place. Now we simply don't care and overwrite it with our
  stuff. This might mean that a user has to install a lua script so that e.g.
  conda environments are visible on the prompt.

Closes: https://github.com/cmderdev/cmder/issues/749