### PR TITLE
Disable history switching behavior of ctrl+tab. Sequential switching.

### DIFF
--- a/config/ConEmu.xml
+++ b/config/ConEmu.xml
@@ -253,7 +253,7 @@
 			<value name="TabsLocation" type="hex" data="01"/>
 			<value name="TabSelf" type="hex" data="01"/>
 			<value name="TabLazy" type="hex" data="01"/>
-			<value name="TabRecent" type="hex" data="01"/>
+			<value name="TabRecent" type="hex" data="00"/>
 			<value name="TabDblClick" type="dword" data="00000001"/>
 			<value name="TabsOnTaskBar" type="hex" data="02"/>
 			<value name="TaskBarOverlay" type="hex" data="01"/>


### PR DESCRIPTION
With regards to #186 pull this in if we still want to change this default.

Do note: If you ctrl+tab once, holding control you can still use the arrow keys.