### PR TITLE
Fix git branch name never shown as dirty

### DIFF
--- a/vendor/clink.lua
+++ b/vendor/clink.lua
@@ -193,7 +193,11 @@ end
  -- @return {bool}
 ---
 function get_git_status()
-    return io.popen("git diff --quiet --ignore-submodules HEAD 2>nul")
+    local file = io.popen("git diff --quiet --ignore-submodules HEAD 2>nul")
+    -- This will get a table with some return stuff
+    -- rc[3] will be the signal, 0 or 1
+    local rc = {file:close()}
+    return rc[3] == 0
 end
 
 function git_prompt_filter()


### PR DESCRIPTION
The problem was that io.popen() returns a file handle and not the return code of the
called program. The problem was introduced by 567889e.

The new code was inspired by
http://stackoverflow.com/a/14031974/1380673

Closes: https://github.com/cmderdev/cmder/pull/971
Closes: https://github.com/cmderdev/cmder/issues/928