### PR TITLE
Suppress profile load error

### DIFF
--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -102,7 +102,7 @@ if (-not (test-path "$ENV:CMDER_ROOT\config\profile.d")) {
 }
 
 pushd $ENV:CMDER_ROOT\config\profile.d
-foreach ($x in ls *.ps1) {
+foreach ($x in (ls *.ps1 2> $null)) {
   # write-host write-host Sourcing $x
   . $x
 }


### PR DESCRIPTION
Suppress profile error when there are no ps1 files to source in config\profile.d