### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The main advantage of Cmder is portability. It is designed to be totally self-co
 
 ## Installation
 
-1. Download the [latest release](https://github.com/cmderdev/cmder/releases/)
+1. Download the [latest release](https://github.com/cmderdev/cmder/releases/). (The download links are at bottom of change log.)
 2. Extract
 3. (optional) Place your own executable files into the `bin` folder to be injected into your PATH.
 4. Run Cmder


### PR DESCRIPTION
Provides one sentence of additional guidance for finding the download links. At the moment, the change log is very long, and it's not clear that there are download links at the bottom of it.  So a brand new user (this happened to me) will not necessarily scroll all the way down, and may interpret the Installation instructions to mean "download the latest release by getting the zip version of the repository" (from Github's "clone or download" button). That almost works, but not quite.

Another alternative is to link to the location on the page, e.g. https://github.com/cmderdev/cmder/releases/#latestdownload  But you would need to update the link every time there is a new release.