### PR TITLE
Parse the original prompt for cwd and env names

### DIFF
--- a/vendor/clink.lua
+++ b/vendor/clink.lua
@@ -18,12 +18,34 @@ dofile(clink_lua_file)
  -- which echo) don't get the ugly '{lamb}' shown.
 ---
 function set_prompt_filter()
+    -- get_cwd() is differently encoded than the clink.prompt.value, so everything other than
+    -- pure ASCII will get garbled. So try to parse the current directory from the original prompt
+    -- and only if that doesn't work, use get_cwd() directly.
+    -- The matching relies on the default prompt which ends in X:\PATH\PATH>
+    -- (no network path possible here!)
+    local old_prompt = clink.prompt.value
+    local cwd = old_prompt:match('.*(.:[^>]*)>')
+    if cwd == nil then cwd = clink.get_cwd() end
+    
+    -- environment systems like pythons virtualenv change the PROMPT and usually
+    -- set some variable. But the variables are differently named and we would never
+    -- get them all, so try to parse the env name out of the PROMPT.
+    -- envs are usually put in round or square parentheses and before the old prompt
+    local env = old_prompt:match('.*%(([^%)]+)%).+:')
+    -- also check for square brackets
+    if env == nil then env = old_prompt:match('.*%[([^%]]+)%].+:') end
+    
+    -- build our own prompt
     -- orig: $E[1;32;40m$P$S{git}{hg}$S$_$E[1;30;40m{lamb}$S$E[0m
     -- color codes: "\x1b[1;37;40m"
-    cwd = clink.get_cwd()
-    prompt = "\x1b[1;32;40m{cwd} {git}{hg} \n\x1b[1;30;40m{lamb} \x1b[0m"
-    new_value = string.gsub(prompt, "{cwd}", cwd)
-    clink.prompt.value = string.gsub(new_value, "{lamb}", "λ")
+    local cmder_prompt = "\x1b[1;32;40m{cwd} {git}{hg} \n\x1b[1;30;40m{lamb} \x1b[0m"
+    cmder_prompt = string.gsub(cmder_prompt, "{cwd}", cwd)
+    if env == nil then
+        lambda = "λ"
+    else
+        lambda = "("..env..") λ"
+    end
+    clink.prompt.value = string.gsub(cmder_prompt, "{lamb}", lambda)
 end
 
 ---


### PR DESCRIPTION
clink.get_cwd() is returning a string which is differently encoded than what
clink.prompt.value expects. This results in garbled path names if the path
condains non-ASCII chars. The (arguable hacky) solution is to parse the old
prompt for the current directory (which breaks if the user sets a PROMPT env var
which is incompatible to the regex used here...).

Also parse out a environment name set by systems like virtualenv or conda: this
could be done more specifically by targeting each such system and using the
usually set environment variable but this would mean that we would have to do
that for each and every such system out there and that is probably not a sane
idea...

Closes: https://github.com/cmderdev/cmder/issues/1054 (garbled prompt)
Closes: https://github.com/cmderdev/cmder/issues/1057 https://github.com/cmderdev/cmder/issues/1056 (environment issues)

Example session:

```cmd
C:\Users\jschulz
λ activate py35

C:\Users\jschulz
(py35) λ cd c:\temp\ü\(hallo)\

c:\temp\ü\(hallo)
(py35) λ
```

A "better" solution would be proper unicode support in clink: https://github.com/mridgers/clink/issues/415