### PR TITLE
Fix bash login when $CMDER_ROOT has spaces

### DIFF
--- a/vendor/cmder.sh
+++ b/vendor/cmder.sh
@@ -43,7 +43,7 @@ fi
 
 if [ -d "${CMDER_ROOT}/config/profile.d" ] ; then
   unset profile_d_scripts
-  pushd ${CMDER_ROOT}/config/profile.d >/dev/null
+  pushd "${CMDER_ROOT}/config/profile.d" >/dev/null
   profile_d_scripts=$(ls ${CMDER_ROOT}/config/profile.d/*.sh 2>/dev/null)
 
   if [ ! "x${profile_d_scripts}" = "x" ] ; then
@@ -55,8 +55,8 @@ if [ -d "${CMDER_ROOT}/config/profile.d" ] ; then
   popd >/dev/null
 fi
 
-if [ -f ${CMDER_ROOT}/config/user-profile.sh ] ; then
-    . ${CMDER_ROOT}/config/user-profile.sh
+if [ -f "${CMDER_ROOT}/config/user-profile.sh" ] ; then
+    . "${CMDER_ROOT}/config/user-profile.sh"
 else
     echo Creating user startup file: "${CMDER_ROOT}/config/user-profile.sh"
     cat <<-eof >"${CMDER_ROOT}/config/user-profile.sh"

--- a/vendor/cmder.sh
+++ b/vendor/cmder.sh
@@ -38,18 +38,18 @@ export PATH
 # Drop *.sh or *.zsh files into "${CMDER_ROOT}\config\profile.d"
 # to source them at startup.
 if [ ! -d "${CMDER_ROOT}/config/profile.d" ] ; then
-  mkdir -p ${CMDER_ROOT}/config/profile.d
+  mkdir -p "${CMDER_ROOT}/config/profile.d"
 fi
 
 if [ -d "${CMDER_ROOT}/config/profile.d" ] ; then
   unset profile_d_scripts
   pushd "${CMDER_ROOT}/config/profile.d" >/dev/null
-  profile_d_scripts=$(ls ${CMDER_ROOT}/config/profile.d/*.sh 2>/dev/null)
+  profile_d_scripts=$(ls *.sh 2>/dev/null)
 
   if [ ! "x${profile_d_scripts}" = "x" ] ; then
     for x in ${profile_d_scripts} ; do
-      # echo Sourcing "${x}"...
-      . $x
+      # echo Sourcing "${CMDER_ROOT}/config/profile.d/${x}"...
+      . "${CMDER_ROOT}/config/profile.d/${x}"
     done
   fi
   popd >/dev/null

--- a/vendor/cmder_exinit
+++ b/vendor/cmder_exinit
@@ -51,29 +51,29 @@ if [ ! "$CMDER_ROOT" = "" ] ; then
   # Drop *.sh or *.zsh files into "${CMDER_ROOT}\config\profile.d"
   # to source them at startup.
   if [ ! -d "${CMDER_ROOT}/config/profile.d" ] ; then
-    mkdir -p ${CMDER_ROOT}/config/profile.d
+    mkdir -p "${CMDER_ROOT}/config/profile.d"
   fi
   
   if [ -d "${CMDER_ROOT}/config/profile.d" ] ; then
     unset profile_d_scripts
-    pushd ${CMDER_ROOT}/config/profile.d >/dev/null
+    pushd "${CMDER_ROOT}/config/profile.d" >/dev/null
     if [ ! "x${ZSH_VERSION}" = "x"  ]; then
-      profile_d_scripts=$(ls ${CMDER_ROOT}/config/profile.d/*.zsh 2>/dev/null)
+      profile_d_scripts=$(ls *.zsh 2>/dev/null)
     elif [ ! "x${BASH_VERSION}" = "x"  ]; then
-      profile_d_scripts=$(ls ${CMDER_ROOT}/config/profile.d/*.sh 2>/dev/null)
+      profile_d_scripts=$(ls *.sh 2>/dev/null)
     fi
   
     if [ ! "x${profile_d_scripts}" = "x" ] ; then
       for x in ${profile_d_scripts} ; do
-        # echo Sourcing "${x}"...
-        . $x
+        # echo Sourcing "${CMDER_ROOT}/config/profile.d/${x}"...
+        . "${CMDER_ROOT}/config/profile.d/${x}"
       done
     fi
     popd >/dev/null
   fi
   
-  if [ -f ${CMDER_ROOT}/config/user-profile.sh ] ; then
-    . ${CMDER_ROOT}/config/user-profile.sh
+  if [ -f "${CMDER_ROOT}/config/user-profile.sh" ] ; then
+    . "${CMDER_ROOT}/config/user-profile.sh"
   else
     echo Creating user startup file: "${CMDER_ROOT}/config/user-profile.sh"
     cat <<-eof >"${CMDER_ROOT}/config/user-profile.sh"


### PR DESCRIPTION
The patch fixed the errors when using bash and cmder is installed under a directory with spaces in the path, e.g. `c:\Users\Foo Bar\cmder` . Please review. Thanks.

The first commit fixed errors I encountered (in v1.3.0), while the second commit fixed similar issues.

Note: The development branch (the base) is behind master, in fact, pre v1.3.0.  Should I stick with merging to it?
