### PR TITLE
Fix for slow startup under certain conditions (#1122)

### DIFF
--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -169,8 +169,7 @@ void StartCmder(std::wstring path, bool is_single_mode)
 		}
 	}
 	// Ensure EnvironmentVariables are propagated.
-	SendMessageTimeout(HWND_BROADCAST, WM_SETTINGCHANGE, 0, (LPARAM)"Environment", SMTO_ABORTIFHUNG, 5000, NULL);
-	SendMessageTimeout(HWND_BROADCAST, WM_SETTINGCHANGE, 0, (LPARAM) L"Environment", SMTO_ABORTIFHUNG, 5000, NULL); // For Windows >= 8
+
 
 	STARTUPINFO si = { 0 };
 	si.cb = sizeof(STARTUPINFO);
@@ -178,12 +177,15 @@ void StartCmder(std::wstring path, bool is_single_mode)
 	si.lpTitle = appId;
 	si.dwFlags = STARTF_TITLEISAPPID;
 #endif
-
 	PROCESS_INFORMATION pi;
 	if (!CreateProcess(conEmuPath, args, NULL, NULL, false, 0, NULL, NULL, &si, &pi)) {
 		MessageBox(NULL, _T("Unable to create the ConEmu Process!"), _T("Error"), MB_OK);
 		return;
 	}
+
+	LRESULT lr = SendMessageTimeout(HWND_BROADCAST, WM_SETTINGCHANGE, 0, (LPARAM)"Environment", SMTO_ABORTIFHUNG | SMTO_NOTIMEOUTIFNOTHUNG, 5000, NULL);
+	lr = SendMessageTimeout(HWND_BROADCAST, WM_SETTINGCHANGE, 0, (LPARAM) L"Environment", SMTO_ABORTIFHUNG | SMTO_NOTIMEOUTIFNOTHUNG, 5000, NULL); // For Windows >= 8
+
 }
 
 bool IsUserOnly(std::wstring opt)


### PR DESCRIPTION
Fixes #1122 by simply calling CreateProcess before the SendMessageTimeout
calls that are used to propagate environment variable changes.