### PR TITLE
Fix typo in config/Readme.md

### DIFF
--- a/config/Readme.md
+++ b/config/Readme.md
@@ -7,7 +7,7 @@ directly, it has to be hardlinked.
   `vendor\aliases.example`.
 * `*.lua`: clink completions and prompt filters; called from vendor\cmder.lua after all
   other prompt filter and clink completions are initialized; add your own.
-* `user_profile.{sh|bat|ps1}`: startup files for bash|cmd|powershell tasks; called from their
+* `user-profile.{sh|bat|ps1}`: startup files for bash|cmd|powershell tasks; called from their
   respective startup scripts in `vendor\`; autocreated on first start of such a task
 * `.history`: the current commandline history; autoupdated on close
 * `settings`: settings for readline; overwritten on update


### PR DESCRIPTION
The file config/Readme.md refers to the "user-profile" files with "_" instead of "-". This fixes that.

The guidelines said that trivial changes on the documentation of existing features can be made directly on master, so that's what I did. 😄 