### PR TITLE
Allow profile.d ps1 file to override prompt

### DIFF
--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -86,19 +86,6 @@ if (Get-Module PSReadline -ErrorAction "SilentlyContinue") {
 # Enhance Path
 $env:Path = "$Env:CMDER_ROOT\bin;$env:Path;$Env:CMDER_ROOT"
 
-# Drop *.ps1 files into "$ENV:CMDER_ROOT\config\profile.d"
-# to source them at startup.
-if (-not (test-path "$ENV:CMDER_ROOT\config\profile.d")) {
-  mkdir "$ENV:CMDER_ROOT\config\profile.d"
-}
-
-pushd $ENV:CMDER_ROOT\config\profile.d
-foreach ($x in ls *.ps1) {
-  # write-host write-host Sourcing $x
-  . $x
-}
-popd
-
 #
 # Prompt Section
 #   Users should modify their user-profile.ps1 as it will be safe from updates.
@@ -112,6 +99,35 @@ popd
     Microsoft.PowerShell.Utility\Write-Host $pwd.ProviderPath -NoNewLine -ForegroundColor Green
     checkGit($pwd.ProviderPath)
 }
+
+<#
+This scriptblock runs every time the prompt is returned.
+Explicitly use functions from MS namespace to protect from being overridden in the user session.
+Custom prompt functions are loaded in as constants to get the same behaviour
+#>
+[ScriptBlock]$Prompt = {
+    $realLASTEXITCODE = $LASTEXITCODE
+    $host.UI.RawUI.WindowTitle = Microsoft.PowerShell.Management\Split-Path $pwd.ProviderPath -Leaf
+    PrePrompt | Microsoft.PowerShell.Utility\Write-Host -NoNewline
+    CmderPrompt
+    Microsoft.PowerShell.Utility\Write-Host "`nλ " -NoNewLine -ForegroundColor "DarkGray"
+    PostPrompt | Microsoft.PowerShell.Utility\Write-Host -NoNewline
+    $global:LASTEXITCODE = $realLASTEXITCODE
+    return " "
+}
+
+# Drop *.ps1 files into "$ENV:CMDER_ROOT\config\profile.d"
+# to source them at startup.
+if (-not (test-path "$ENV:CMDER_ROOT\config\profile.d")) {
+  mkdir "$ENV:CMDER_ROOT\config\profile.d"
+}
+
+pushd $ENV:CMDER_ROOT\config\profile.d
+foreach ($x in ls *.ps1) {
+  # write-host write-host Sourcing $x
+  . $x
+}
+popd
 
 $CmderUserProfilePath = Join-Path $env:CMDER_ROOT "config\user-profile.ps1"
 if(Test-Path $CmderUserProfilePath) {
@@ -159,22 +175,6 @@ New-Item -ItemType File -Path $CmderUserProfilePath -Value $UserProfileTemplate 
 Set-Item -Path function:\PrePrompt   -Value $PrePrompt   -Options Constant
 Set-Item -Path function:\CmderPrompt -Value $CmderPrompt -Options Constant
 Set-Item -Path function:\PostPrompt  -Value $PostPrompt  -Options Constant
-
-<#
-This scriptblock runs every time the prompt is returned.
-Explicitly use functions from MS namespace to protect from being overridden in the user session.
-Custom prompt functions are loaded in as constants to get the same behaviour
-#>
-[ScriptBlock]$Prompt = {
-    $realLASTEXITCODE = $LASTEXITCODE
-    $host.UI.RawUI.WindowTitle = Microsoft.PowerShell.Management\Split-Path $pwd.ProviderPath -Leaf
-    PrePrompt | Microsoft.PowerShell.Utility\Write-Host -NoNewline
-    CmderPrompt
-    Microsoft.PowerShell.Utility\Write-Host "`nλ " -NoNewLine -ForegroundColor "DarkGray"
-    PostPrompt | Microsoft.PowerShell.Utility\Write-Host -NoNewline
-    $global:LASTEXITCODE = $realLASTEXITCODE
-    return " "
-}
 
 # Functions can be made constant only at creation time
 # ReadOnly at least requires `-force` to be overwritten


### PR DESCRIPTION
The *.ps1 files in the profile.d/ directory should be run _after_ the default prompt variables ($PrePrompt, $PostPrompt, and $CmderPrompt) are defined, so that those profile files can have access to overwrite them, otherwise the prompt can _only_ be set via user-profile.ps1.