### PR TITLE
Changed the way directory is defined .git

### DIFF
--- a/vendor/clink.lua
+++ b/vendor/clink.lua
@@ -118,7 +118,7 @@ local function get_git_dir(path)
 
     -- Checks if provided directory contains git directory
     local function has_git_dir(dir)
-        return #clink.find_dirs(dir..'/.git') > 0 and dir..'/.git'
+        return clink.is_dir(dir..'/.git') and dir..'/.git'
     end
 
     local function has_git_file(dir)


### PR DESCRIPTION
`clink.find_dirs` - do not specify the directory if there is Cyrillic in the way.
`clink.is_dir` - more logical and faster.

![default](https://cloud.githubusercontent.com/assets/20110612/23759647/6b74d8ce-04fe-11e7-9b2a-2d2ef2c339ff.png)
