### PR TITLE
Fixed quotation marks BUG

### DIFF
--- a/bin/alias.bat
+++ b/bin/alias.bat
@@ -96,7 +96,7 @@ set del_alias=%~1
 findstr /b /v /i "%del_alias%=" "%ALIASES%" >> "%ALIASES%.tmp"
 type "%ALIASES%".tmp > "%ALIASES%" & @del /f /q "%ALIASES%.tmp"
 doskey %del_alias%=
-doskey /macrofile=%ALIASES%
+doskey /macrofile="%ALIASES%"
 goto:eof
 
 :p_reload

--- a/config/ConEmu.xml
+++ b/config/ConEmu.xml
@@ -548,14 +548,14 @@
 					<value name="GuiArgs" type="string" data=" /icon &quot;%CMDER_ROOT%\icons\cmder.ico&quot;"/>
 					<value name="Active" type="dword" data="00000000"/>
 					<value name="Count" type="dword" data="00000001"/>
-					<value name="Cmd1" type="string" data="*cmd /c &quot;%ConEmuDir%\..\git-for-windows\bin\bash --login -i&quot; -new_console:d:%USERPROFILE%"/>
+					<value name="Cmd1" type="string" data="*cmd /c &quot;%ConEmuDir%\..\git-for-windows\bin\bash&quot; --login -i -new_console:d:%USERPROFILE%"/>
 				</key>
 				<key name="Task8" modified="2015-11-24 14:49:10" build="151119">
 					<value name="Name" type="string" data="{bash::bash}"/>
 					<value name="Flags" type="dword" data="00000000"/>
 					<value name="Hotkey" type="dword" data="00000000"/>
 					<value name="GuiArgs" type="string" data=" /icon &quot;%CMDER_ROOT%\icons\cmder.ico&quot;"/>
-					<value name="Cmd1" type="string" data="cmd /c &quot;%ConEmuDir%\..\git-for-windows\bin\bash --login -i&quot; -new_console:d:%USERPROFILE%"/>
+					<value name="Cmd1" type="string" data="cmd /c &quot;%ConEmuDir%\..\git-for-windows\bin\bash&quot; --login -i -new_console:d:%USERPROFILE%"/>
 					<value name="Active" type="dword" data="00000000"/>
 					<value name="Count" type="dword" data="00000001"/>
 				</key>


### PR DESCRIPTION
1. Changed " --login -i&quot;" to "&quot; --login -i" in ConEmu
2. Closed quotation in "alias.bat :p_del doskey" command of "%ALIASES%"

Suppose %CMDER_ROOT% is "C:\Program Files\cmder",
this BUG will be raised while we exec command of

"unalias xxx"
or creat terminal "{bash::bash}"
and "{bash::mintty}",

it will throws an error like:
'C:\Program' is not recognized as an internal or external command,
operable program or batch file.