### PR TITLE
Added pagent ssh auth support

### DIFF
--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -173,7 +173,14 @@ if exist "%CMDER_ROOT%\config\user-profile.cmd" (
     echo :: use this file to run your own startup commands
     echo :: use  in front of the command to prevent printing the command
     echo.
+    echo :: uncomment this to have the ssh agent load when cmder starts
     echo :: call "%%GIT_INSTALL_ROOT%%/cmd/start-ssh-agent.cmd"
+    echo.
+    echo :: uncomment this next two lines to use pageant as the ssh authentication agent
+    echo :: SET SSH_AUTH_SOCK=/tmp/.ssh-pageant-auth-sock
+    echo :: call "%%GIT_INSTALL_ROOT%%/cmd/start-ssh-pageant.cmd"
+    echo.
+    echo :: you can add your plugins to the cmder path like so
     echo :: set "PATH=%%CMDER_ROOT%%\vendor\whatever;%%PATH%%"
     echo.
     ) > "%CMDER_ROOT%\config\user-profile.cmd"


### PR DESCRIPTION
(and some comments on the user-profile.cmd file)

Inspired by the comments from #193 and my personal need to use pageant instead of OpenSSH authentication agents (which is more Window user-friendly), I have used this approach which works as expected.

Keeping the spirit of the current scripts, I left it disabled, and with some comments explaining what they all do.