### PR TITLE
add /TASK option

### DIFF
--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -95,7 +95,7 @@ bool FileExists(const wchar_t * filePath)
 	return false;
 }
 
-void StartCmder(std::wstring path, bool is_single_mode)
+void StartCmder(std::wstring path, bool is_single_mode, std::wstring taskName = L"")
 {
 #if USE_TASKBAR_API
 	wchar_t appId[MAX_PATH] = { 0 };
@@ -178,6 +178,10 @@ void StartCmder(std::wstring path, bool is_single_mode)
 	else
 	{
 		swprintf_s(args, L"/Icon \"%s\" /Title Cmder", icoPath);
+	}
+
+	if (!taskName.empty()) {
+		swprintf_s(args, L"%s -run {%s}", args, taskName.c_str());
 	}
 
 	SetEnvironmentVariable(L"CMDER_ROOT", exeDir);
@@ -323,6 +327,10 @@ int APIENTRY _tWinMain(_In_ HINSTANCE hInstance,
 	{
 		StartCmder(opt.second, true);
 	}
+	else if (streqi(opt.first.c_str(), L"/TASK"))
+	{
+		StartCmder(L"", false, opt.second);
+	}
 	else if (streqi(opt.first.c_str(), L"/REGISTER"))
 	{
 		RegisterShellMenu(opt.second, SHELL_MENU_REGISTRY_PATH_BACKGROUND);
@@ -335,7 +343,7 @@ int APIENTRY _tWinMain(_In_ HINSTANCE hInstance,
 	}
 	else
 	{
-		MessageBox(NULL, L"Unrecognized parameter.\n\nValid options:\n  /START <path>\n  /SINGLE <path>\n  /REGISTER [USER/ALL]\n  /UNREGISTER [USER/ALL]", MB_TITLE, MB_OK);
+		MessageBox(NULL, L"Unrecognized parameter.\n\nValid options:\n  /START <path>\n  /SINGLE <path>\n  /TASK <name>\n /REGISTER [USER/ALL]\n  /UNREGISTER [USER/ALL]", MB_TITLE, MB_OK);
 		return 1;
 	}
 

--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -181,7 +181,7 @@ void StartCmder(std::wstring path, bool is_single_mode, std::wstring taskName = 
 	}
 
 	if (!taskName.empty()) {
-		swprintf_s(args, L"%s -run {%s}", args, taskName.c_str());
+		swprintf_s(args, L"%s /run {%s}", args, taskName.c_str());
 	}
 
 	SetEnvironmentVariable(L"CMDER_ROOT", exeDir);


### PR DESCRIPTION
If this application has the /TASK option, we can start it with the specified task name. Of course, the task name must exist in Settings -> Startup -> Tasks.

Usage:
e.g. Cmder.exe /TASK WSL-Ubuntu
e.g. Cmder.exe /TASK Cmder

Thx