### PR TITLE
allow cmder (cmd) to start in network locations

### DIFF
--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -160,7 +160,7 @@ if not defined HOME set "HOME=%USERPROFILE%"
 :: This is either a env variable set by the user or the result of
 :: cmder.exe setting this variable due to a commandline argument or a "cmder here"
 if defined CMDER_START (
-    cd /d "%CMDER_START%"
+    PUSHD "%CMDER_START%\"
 )
 
 


### PR DESCRIPTION
`PUSHD` instead of `CD /D` allows the use of UNC paths with cmd.
PUSHD temporarily maps a network drive to Z: and in this way allows cmd to with those paths.
The trailing `\` is important for the command to work in certain cases.