### PR TITLE
Avoid using aliases in profile.ps1

### DIFF
--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -127,7 +127,7 @@ if (-not (test-path "$ENV:CMDER_ROOT\config\profile.d")) {
 }
 
 pushd $ENV:CMDER_ROOT\config\profile.d
-foreach ($x in ls *.ps1) {
+foreach ($x in Get-ChildItem *.ps1) {
   # write-host write-host Sourcing $x
   . $x
 }


### PR DESCRIPTION
Aliases such as `ls` may have been overridden in the user's profile script and the resulting behavior may be different from `Get-ChildItem`. For example binding `ls` to GNU `ls.exe` generates an error if there are no files matching `*.ps1`.