### PR TITLE
Fix alias.bat handling "user-aliases.cmd" with spaces

### DIFF
--- a/bin/alias.bat
+++ b/bin/alias.bat
@@ -1,8 +1,8 @@
 @echo off
 
 
-if "%aliases%" == "" (
-  set ALIASES=%CMDER_ROOT%\config\user-aliases.cmd
+if "%ALIASES%" == "" (
+  set aliases="%CMDER_ROOT%\config\user-aliases.cmd"
 )
 
 setlocal enabledelayedexpansion
@@ -50,16 +50,16 @@ goto parseargument
   )
 rem #endregion parseargument
 
-if "%aliases%" neq "%CMDER_ROOT%\config\user-aliases.cmd" (
-  set _x=!_x:/f %aliases% =!
+if "%ALIASES%" neq "%CMDER_ROOT%\config\user-aliases.cmd" (
+  set _x=!_x:/f "%ALIASES%" =!
 
-  if not exist "%aliases%" (
-    echo ;= @echo off>"%aliases%"
-    echo ;= rem Call DOSKEY and use this file as the macrofile>>"%aliases%"
-    echo ;= %%SystemRoot%%\system32\doskey /listsize=1000 /macrofile=%%0%%>>"%aliases%"
-    echo ;= rem In batch mode, jump to the end of the file>>"%aliases%"
-    echo ;= goto:eof>>"%aliases%"
-    echo ;= Add aliases below here>>"%aliases%"
+  if not exist "%ALIASES%" (
+    echo ;= @echo off>"%ALIASES%"
+    echo ;= rem Call DOSKEY and use this file as the macrofile>>"%ALIASES%"
+    echo ;= %%SystemRoot%%\system32\doskey /listsize=1000 /macrofile=%%0%%>>"%ALIASES%"
+    echo ;= rem In batch mode, jump to the end of the file>>"%ALIASES%"
+    echo ;= goto:eof>>"%ALIASES%"
+    echo ;= Add aliases below here>>"%ALIASES%"
   )
 )
 

--- a/bin/alias.bat
+++ b/bin/alias.bat
@@ -2,7 +2,7 @@
 
 
 if "%ALIASES%" == "" (
-  set aliases="%CMDER_ROOT%\config\user-aliases.cmd"
+  set ALIASES="%CMDER_ROOT%\config\user-aliases.cmd"
 )
 
 setlocal enabledelayedexpansion
@@ -21,7 +21,7 @@ goto parseargument
   set currentarg=%~1
 
   if /i "%currentarg%" equ "/f" (
-    set aliases=%~2
+    set ALIASES=%~2
     shift
     goto :do_shift
   ) else if /i "%currentarg%" == "/reload" (
@@ -110,11 +110,11 @@ exit /b
 
 :p_help
 echo.Usage:
-echo. 
+echo.
 echo.	alias [options] [alias=full command]
-echo. 
+echo.
 echo.Options:
-echo. 
+echo.
 echo.     /d [alias]     Delete an [alias].
 echo.     /f [macrofile] Path to the [macrofile] you want to store the new alias in.
 echo.                    Default: %cmder_root%\config\user-aliases.cmd


### PR DESCRIPTION
This fixes the alias command when user-aliases.cmd is located in a path with spaces (like when Cmder is installed into the program-files directory).
I've also made the alphabetical case of the ALIASES variable consistent.