### PR TITLE
Add args to init.bat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ build/
 Version v*
 *.bak
 config/user-*
+config/ConEmu-*
 config/settings
 config/aliases
 config/profile.d

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ echo source \$CMDER_ROOT/vendor/mintty-colors-solarized/mintty-solarized-dark.sh
 -a [user alias file path]    File path pointing to user aliases.
                              Default: '%CMDER_ROOT%\config\user-liases.cmd' 
 
--c [user cmder user root]]   User specified Cmder folder.  Allows for a shared install of Cmder with individual user configuratons.
-                             Default: The location of the Cmder.exe file.
+-c [user cmder user root]]   User specified Cmder root folder.  Allows for a shared install of Cmder with individual user configuratons.
+                             Default: None
 
 -d [startup folder]          User specified startup folder.
                              Default: '%userprofile%'

--- a/README.md
+++ b/README.md
@@ -85,6 +85,39 @@ cd mintty-colors-solarized/
 echo source \$CMDER_ROOT/vendor/mintty-colors-solarized/mintty-solarized-dark.sh>>$CMDER_ROOT/config/user-profile.sh
 ```
 
+### Changing Cmder Default 'cmd.exe' Shell Startup
+
+1. Press <kbd>Win</kbd> + <kbd>Alt</kbd> + <kbd>T</kbd>
+1. Click either:
+  * `1. {cmd::Cmder as Admin}`
+  * `2. {cmd::Cmder}`
+1. Change `cmd /k "%ConEmuDir%\..\init.bat"` to `cmd /k ""%ConEmuDir%\..\init.bat" "`.  NOTE: The extra quotes and spacing around `"%ConEmuDir%\..\init.bat"`
+1. Add command line arguments after `"%ConEmuDir%\..\init.bat" `
+
+##### Command Line Arguments for `init.bat`
+
+```
+-a [user alias file path]    File path pointing to user aliases.
+                             Default: '%CMDER_ROOT%\config\user-liases.cmd' 
+
+-c [user cmder user root]]   User specified Cmder folder.  Allows for a shared install of Cmder with individual user configuratons.
+                             Default: The location of the Cmder.exe file.
+
+-d [startup folder]          User specified startup folder.
+                             Default: '%userprofile%'
+
+-g [git install root]        User specified Git installation root path.
+                             Default: '%CMDER_ROOT%\vendor\Git for Windows'
+
+-h [home folder]             User specified folder path to set `%HOME%` environment variable.
+                             Default: '%userprofile%'
+
+-s [path to ssh.exe]         Define %SVN_SSH% so we can use git svn with ssh svn repositories.
+                             Default: '%GIT_INSTALL_ROOT%\bin\ssh.exe'
+
+-v                           Enables verbose output.
+```
+
 ### Cmder Portable Shell User Config
 User specific configuration is possible using the cmder specific shell config files.  Edit the below files to add your own configuration:
 

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -152,7 +152,7 @@ if defined GIT_INSTALL_ROOT (
 
 :NO_GIT
 endlocal & set "PATH=%PATH%" & set "SVN_SSH=%SVN_SSH%" & set "GIT_INSTALL_ROOT=%GIT_INSTALL_ROOT%"
-call :verbose-output GIT_INSTALL_ROOT-output=%GIT_INSTALL_ROOT-output%
+call :verbose-output GIT_INSTALL_ROOT=%GIT_INSTALL_ROOT%
 
 :: Enhance Path
 set "PATH=%CMDER_ROOT%\bin;%PATH%;%CMDER_ROOT%\"

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -6,8 +6,65 @@
 :: !!! THIS FILE IS OVERWRITTEN WHEN CMDER IS UPDATED
 :: !!! Use "%CMDER_ROOT%\config\user-profile.cmd" to add your own startup commands
 
-:: Set to > 0 for verbose output to aid in debugging.
-if not defined verbose-output ( set verbose-output=0 )
+:: Use -v command line arg or set to > 0 for verbose output to aid in debugging.
+set verbose-output=0
+
+:var_loop
+    if "%1"=="-v" (
+        set verbose-output=1
+    ) else if "%1" == "-a" (
+        if exist "%~2" (
+            set "user-aliases=%~2"
+            shift
+        ) else (
+            call :show_error The user aliases file, "%~2", you specified does not exist!
+            exit /b
+        )
+    ) else if "%1" == "-c" (
+        if not exist "%~2" (
+            echo WARNING: The CMDER user root folder "%~2", you specified does not exist!
+        )
+        if not exist "%~2\config\profile.d" md "%~2\config\profile.d"
+        if not exist "%~2\bin"  md "%~2\bin"
+        set "CMDER_USER_ROOT=%~2"
+        shift
+    ) else if "%1" == "-d" (
+        if exist "%~2" (
+          set "CMDER_START=%~2"
+          shift
+        ) else (
+          call :show_error The CMDER startup folder "%2", you specified does not exist!
+          exit /b
+        )
+    ) else if "%1" == "-g" (
+        if exist "%~2" (
+            set "GIT_INSTALL_ROOT=%~2"
+            shift
+        ) else (
+            call :show_error The Git install root folder "%2", you specified does not exist!
+            exit /b
+        )
+    ) else if "%1" == "-h" (
+        if exist "%~2" (
+            set "HOME=%~2"
+            shift
+        ) else (
+            call :show_error The home folder "%2", you specified does not exist!
+            exit /b
+        )
+    ) else if "%1" == "-s" (
+        set SVN_SSH=%2
+        shift
+    ) else (
+        goto :start
+    )
+    shift
+goto var_loop
+
+:start
+
+call :verbose-output verbose-output=%verbose-output%
+call :verbose-output CMDER_USER_ROOT=%CMDER_USER_ROOT%
 
 :: Find root dir
 if not defined CMDER_ROOT (
@@ -18,8 +75,9 @@ if not defined CMDER_ROOT (
     )
 )
 
-:: Remove trailing '\'
+:: Remove trailing '\' from %CMDER_ROOT%
 if "%CMDER_ROOT:~-1%" == "\" SET "CMDER_ROOT=%CMDER_ROOT:~0,-1%"
+call :verbose-output CMDER_ROOT=%CMDER_ROOT%
 
 :: Pick right version of clink
 if "%PROCESSOR_ARCHITECTURE%"=="x86" (
@@ -35,7 +93,11 @@ if not exist "%CMDER_ROOT%\config\settings" (
 )
 
 :: Run clink
-"%CMDER_ROOT%\vendor\clink\clink_x%architecture%.exe" inject --quiet --profile "%CMDER_ROOT%\config" --scripts "%CMDER_ROOT%\vendor"
+if defined CMDER_USER_ROOT (
+    "%CMDER_ROOT%\vendor\clink\clink_x%architecture%.exe" inject --quiet --profile "%CMDER_USER_ROOT%\config" --scripts "%CMDER_ROOT%\vendor"
+) else (
+    "%CMDER_ROOT%\vendor\clink\clink_x%architecture%.exe" inject --quiet --profile "%CMDER_ROOT%\config" --scripts "%CMDER_ROOT%\vendor"
+)
 
 :: Prepare for git-for-windows
 
@@ -91,22 +153,17 @@ if defined GIT_INSTALL_ROOT (
 
 :NO_GIT
 endlocal & set "PATH=%PATH%" & set "SVN_SSH=%SVN_SSH%" & set "GIT_INSTALL_ROOT=%GIT_INSTALL_ROOT%"
+call :verbose-output GIT_INSTALL_ROOT-output=%GIT_INSTALL_ROOT-output%
 
 :: Enhance Path
 set "PATH=%CMDER_ROOT%\bin;%PATH%;%CMDER_ROOT%\"
 
 :: Drop *.bat and *.cmd files into "%CMDER_ROOT%\config\profile.d"
 :: to run them at startup.
-if not exist "%CMDER_ROOT%\config\profile.d" (
-  mkdir "%CMDER_ROOT%\config\profile.d"
+call :run_profile_d "%CMDER_ROOT%\config\profile.d"
+if defined CMDER_USER_ROOT (
+  call :run_profile_d "%CMDER_USER_ROOT%\config\profile.d"
 )
-
-pushd "%CMDER_ROOT%\config\profile.d"
-for /f "usebackq" %%x in ( `dir /b *.bat *.cmd 2^>nul` ) do (
-  call :verbose-output Calling "%CMDER_ROOT%\config\profile.d\%%x"...
-  call "%CMDER_ROOT%\config\profile.d\%%x"
-)
-popd
 
 :: Allows user to override default aliases store using profile.d
 :: scripts run above by setting the 'aliases' env variable.
@@ -114,7 +171,13 @@ popd
 :: Note: If overriding default aliases store file the aliases
 :: must also be self executing, see '.\user-aliases.cmd.example',
 :: and be in profile.d folder.
-set "user-aliases=%CMDER_ROOT%\config\user-aliases.cmd"
+if not defined user-aliases (
+  if defined CMDER_USER_ROOT (
+     set "user-aliases=%CMDER_USER_ROOT%\config\user-aliases.cmd"
+  ) else (
+     set "user-aliases=%CMDER_ROOT%\config\user-aliases.cmd"
+  )
+)
 
 :: The aliases environment variable is used by alias.bat to id
 :: the default file to store new aliases in.
@@ -131,8 +194,13 @@ if not exist "%user-aliases%" (
     type "%user-aliases%" | findstr /i ";= Add aliases below here" >nul
     if "!errorlevel!" == "1" (
         echo Creating initial user-aliases store in "%user-aliases%"...
-        copy "%CMDER_ROOT%\%user-aliases%" "%user-aliases%.old_format"
-        copy "%CMDER_ROOT%\vendor\user-aliases.cmd.example" "%user-aliases%"
+        if defined CMDER_USER_ROOT (
+            copy "%user-aliases%" "%user-aliases%.old_format"
+            copy "%CMDER_ROOT%\vendor\user-aliases.cmd.example" "%user-aliases%"
+        ) else (
+            copy "%user-aliases%" "%user-aliases%.old_format"
+            copy "%CMDER_ROOT%\vendor\user-aliases.cmd.example" "%user-aliases%"
+        )
     )
 )
 
@@ -145,6 +213,7 @@ if exist "%CMDER_ROOT%\config\aliases" (
   type "%user-aliases%.old_format" >> "%user-aliases%" && del "%user-aliases%.old_format"
 )
 endlocal
+
 :: Add aliases to the environment
 call "%user-aliases%"
 
@@ -160,28 +229,41 @@ if exist "%CMDER_ROOT%\vendor\git-for-windows\post-install.bat" (
 
 :: Set home path
 if not defined HOME set "HOME=%USERPROFILE%"
+call :verbose-output HOME=%HOME%
 
-if exist "%CMDER_ROOT%\config\user-profile.cmd" (
+if exist "%CMDER_USER_ROOT%\config\user-profile.cmd" (
+    REM Create this file and place your own command in there
+    call "%CMDER_USER_ROOT%\config\user-profile.cmd"
+) else if exist "%CMDER_ROOT%\config\user-profile.cmd" (
     REM Create this file and place your own command in there
     call "%CMDER_ROOT%\config\user-profile.cmd"
 ) else (
     echo Creating user startup file: "%CMDER_ROOT%\config\user-profile.cmd"
     (
-    echo :: use this file to run your own startup commands
-    echo :: use  in front of the command to prevent printing the command
-    echo.
-    echo :: uncomment this to have the ssh agent load when cmder starts
-    echo :: call "%%GIT_INSTALL_ROOT%%/cmd/start-ssh-agent.cmd"
-    echo.
-    echo :: uncomment this next two lines to use pageant as the ssh authentication agent
-    echo :: SET SSH_AUTH_SOCK=/tmp/.ssh-pageant-auth-sock
-    echo :: call "%%GIT_INSTALL_ROOT%%/cmd/start-ssh-pageant.cmd"
-    echo.
-    echo :: you can add your plugins to the cmder path like so
-    echo :: set "PATH=%%CMDER_ROOT%%\vendor\whatever;%%PATH%%"
-    echo.
-    ) > "%CMDER_ROOT%\config\user-profile.cmd"
+echo :: use this file to run your own startup commands
+echo :: use  in front of the command to prevent printing the command
+echo.
+echo :: uncomment this to have the ssh agent load when cmder starts
+echo :: call "%%GIT_INSTALL_ROOT%%/cmd/start-ssh-agent.cmd"
+echo.
+echo :: uncomment this next two lines to use pageant as the ssh authentication agent
+echo :: SET SSH_AUTH_SOCK=/tmp/.ssh-pageant-auth-sock
+echo :: call "%%GIT_INSTALL_ROOT%%/cmd/start-ssh-pageant.cmd"
+echo.
+echo :: you can add your plugins to the cmder path like so
+echo :: set "PATH=%%CMDER_ROOT%%\vendor\whatever;%%PATH%%"
+echo.
+echo @echo off
+) >"%temp%\user-profile.tmp"
+
+  if defined CMDER_USER_ROOT (
+    copy "%temp%\user-profile.tmp" "%CMDER_USER_ROOT%\config\user-profile.cmd"
+  ) else (
+    copy "%temp%\user-profile.tmp" "%CMDER_ROOT%\config\user-profile.cmd"
+  )
 )
+
+if defined CMDER_START cd /d %CMDER_START%
 
 exit /b
 
@@ -191,3 +273,21 @@ exit /b
 :verbose-output
     if %verbose-output% gtr 0 echo %*
     exit /b
+
+:show_error
+    echo ERROR: %*
+    echo CMDER Shell Initialization has Failed!
+    exit /b
+
+:run_profile_d
+  if not exist "%~1" (
+    mkdir "%~1"
+  )
+
+  pushd "%~1"
+  for /f "usebackq" %%x in ( `dir /b *.bat *.cmd 2^>nul` ) do (
+    call :verbose-output Calling "%~1\%%x"...
+    call "%~1\%%x"
+  )
+  popd
+  exit /b

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -17,8 +17,7 @@ set verbose-output=0
             set "user-aliases=%~2"
             shift
         ) else (
-            call :show_error The user aliases file, "%~2", you specified does not exist!
-            exit /b
+            echo WARNING:The user aliases file, "%~2", you specified does not exist!
         )
     ) else if "%1" == "-c" (
         if not exist "%~2" (

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -198,13 +198,8 @@ if not exist "%user-aliases%" (
     type "%user-aliases%" | findstr /i ";= Add aliases below here" >nul
     if "!errorlevel!" == "1" (
         echo Creating initial user-aliases store in "%user-aliases%"...
-        if defined CMDER_USER_ROOT (
-            copy "%user-aliases%" "%user-aliases%.old_format"
-            copy "%CMDER_ROOT%\vendor\user-aliases.cmd.example" "%user-aliases%"
-        ) else (
-            copy "%user-aliases%" "%user-aliases%.old_format"
-            copy "%CMDER_ROOT%\vendor\user-aliases.cmd.example" "%user-aliases%"
-        )
+        copy "%user-aliases%" "%user-aliases%.old_format"
+        copy "%CMDER_ROOT%\vendor\user-aliases.cmd.example" "%user-aliases%"
     )
 )
 

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -158,6 +158,10 @@ call :verbose-output GIT_INSTALL_ROOT-output=%GIT_INSTALL_ROOT-output%
 :: Enhance Path
 set "PATH=%CMDER_ROOT%\bin;%PATH%;%CMDER_ROOT%\"
 
+if defined CMDER_USER_ROOT (
+    set "PATH=%CMDER_USER_ROOT%\bin;%PATH%"
+)
+
 :: Drop *.bat and *.cmd files into "%CMDER_ROOT%\config\profile.d"
 :: to run them at startup.
 call :run_profile_d "%CMDER_ROOT%\config\profile.d"


### PR DESCRIPTION
### Adds

1.  Add ability to take command line args to init.bat.  See README.md for full documentation.
```
-a [user alias file path]    File path pointing to user aliases.
                             Default: '%CMDER_ROOT%\config\user-aliases.cmd'

-c [user cmder user root]]   User specified Cmder root folder.  Allows for a shared install of Cmder with individual user configuratons.
                             Default: None

-d [startup folder]          User specified startup folder.
                             Default: '%userprofile%'

-g [git install root]        User specified Git installation root path.
                             Default: '%CMDER_ROOT%\vendor\Git for Windows'

-h [home folder]             User specified folder path to set `%HOME%` environment variable.
                             Default: '%userprofile%'

-s [path to ssh.exe]         Define %SVN_SSH% so we can use git svn with ssh svn repositories.
                             Default: '%GIT_INSTALL_ROOT%\bin\ssh.exe'

-v                          Enables verbose output.
```

2.  Allow through init.bat command line args a shared install of Cmder with user specific config dir.

    * Set tasks command line to be 'cmd /s /k ""%ConEmuDir%\..\init.bat" -c %USERPROFILE%\cmder_user" -new_console:%USERPROFILE%'