### PR TITLE
simplified λ prompt in lua

### DIFF
--- a/vendor/clink.lua
+++ b/vendor/clink.lua
@@ -40,7 +40,7 @@ local function set_prompt_filter()
     -- orig: $E[1;32;40m$P$S{git}{hg}$S$_$E[1;30;40m{lamb}$S$E[0m
     -- color codes: "\x1b[1;37;40m"
     local cmder_prompt = "\x1b[1;32;40m{cwd} {git}{hg}{svn} \n\x1b[1;39;40m{lamb} \x1b[0m"
-    local lambda = "$"
+    local lambda = "λ"
     cmder_prompt = string.gsub(cmder_prompt, "{cwd}", cwd)
     if env ~= nil then
         lambda = "("..env..") "..lambda

--- a/vendor/sources.json
+++ b/vendor/sources.json
@@ -1,8 +1,8 @@
 [
     {
         "name": "git-for-windows",
-        "version": "v2.15.1.windows.2",
-        "url": "https://github.com/git-for-windows/git/releases/download/v2.15.1.windows.2/PortableGit-2.15.1.2-64-bit.7z.exe"
+        "version": "v2.16.1.windows.4",
+        "url": "https://github.com/git-for-windows/git/releases/download/v2.16.1.windows.4/PortableGit-2.16.1.4-64-bit.7z.exe"
     },
     {
         "name": "clink",

--- a/vendor/sources.json
+++ b/vendor/sources.json
@@ -11,8 +11,8 @@
     },
     {
         "name": "conemu-maximus5",
-        "version": "171226",
-        "url": "https://github.com/Maximus5/ConEmu/releases/download/v17.12.26/ConEmuPack.171226.7z"
+        "version": "180206",
+        "url": "https://github.com/Maximus5/ConEmu/releases/download/v18.02.06/ConEmuPack.180206.7z"
     },
     {
         "name": "clink-completions",


### PR DESCRIPTION
The lambda (λ) character for the prompt is defined only once instead of twice, making it easy for customizations to change shell handle character.