### PR TITLE
New cmder.exe args and shared install capability

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+*.cmd text eol=crlf
+*.bat text eol=crlf
+*.ps1 text eol=crlf
+*.md text eol=lf
+*.sh text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,60 @@
 # Change Log
 
+## [1.3.6-pre1](https://github.com/cmderdev/cmder) (2018-03-01)
+
+**Fixed bugs:**
+
+* Fixed Git version check recently added to master.
+
+**Updates:**
+
+* Modified Cmder tasks in default Conemu.xml to allow easily adding command line args for init.bat by adding some quotes.  This resulted in a ton of misc changes to this file.  See Adds below.
+* Reworked `cmder.exe` command line argument handling to make it more flexible and easily added to.
+* Reworked README.md tables to make them more readable in editors
+
+**Implemented enhancements:**
+
+* Added `cmder.exe` command line args documenttion to `README.md`
+* Added `:enhance_path` method to vendor\init.bat that modifies the path only if required.
+   * To prepend: `call :enhance_path "%cmder_root%"`
+   * to append: `call :enhance_path "%cmder_root%" append`
+* Added `:enhance_path_recursive` method to vendor\init.bat that adds a path and all its sub directories to the path if required.  
+   * Max recurse depth default is '1' configurable using `init.bat /max_depth [1-5]`. 6+ results in error. 
+   * To prepend and go 3 levels deep: `call :enhance_path "%cmder_root%" 3`
+   * To append and go 2 levels deep: `call :enhance_path "%cmder_root%" 2 append`
+* Added ability to init.bat to accept command line args and documented them in README.md.  Allows users to change the behaviour of init.bat without editing the file.
+
+| Argument                      | Description                                                                                      | Default                               |
+| ----------------------------- | ----------------------------------------------------------------------------------------------   | ------------------------------------- |
+| /c [user cmder root]          | Enables user bin and config folders for 'Cmder as admin' sessions due to non-shared environment. | not set                               |
+| /d                            | Enables debug output.                                                                            | not set                               |
+| /git_install_root [file path] | User specified Git installation root path.                                                       | '%CMDER_ROOT%\vendor\Git-for-Windows' |
+| /home [home folder]           | User specified folder path to set `%HOME%` environment variable.                                 | '%userprofile%'                       |
+| /max_depth [1-5]              | Define max recurse depth when adding to the path for `%cmder_root%\bin` and `%cmder_user_bin%`   | 1                                     |
+| /svn_ssh [path to ssh.exe]    | Define %SVN_SSH% so we can use git svn with ssh svn repositories.                                | '%GIT_INSTALL_ROOT%\bin\ssh.exe'      |
+| /user_aliases [file path]     | File path pointing to user aliases.                                                              | '%CMDER_ROOT%\config\user-liases.cmd' |
+| /v                            | Enables verbose output.                                                                          | not set                               |
+
+* Added new `cmder.exe /C \<path\>` argument
+   * To use run Cmder.exe with "/C" command line argument. Example: `cmder.exe /C %userprofile%\cmder_config`
+   * To use run with `Cmder as Admin` sessions you must specify "/c" command line argument to `init.bat` in tasks. See [README.md](./Readme.md) for details.
+   * Enables shared Cmder install with Non-Portable Individual User Config
+   * Supported by all supported shells (cmder, powershell, git bash, and external bash)
+   * This will create the following directory structure if it is missing.
+
+      ```
+      c:\users\[username]\cmder_config
+      ├───bin
+      └───config
+          └───profile.d
+      ```
+
+   * Shell init scripts run in the following order
+      1. %cmder_root%\config\profile.d\*.[cmd|ps1|sh]
+      1. %cmder_root%\config\user-profile.[cmd|ps1|sh]
+      1. %userprofile%\cmder_config\config\profile.d\*.[cmd|ps1|sh]
+      1. %userprofile%\cmder_config\config\user-profile.[cmd|ps1|sh]
+
 ## [1.3.5](https://github.com/cmderdev/cmder/releases/tag/v1.3.5) (2018-02-11)
 
 This is the first Cmder release that comes with Git for Windows in the 64bit version. If you are still using a 32bit version, you have to fix this yourself.

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ echo source \$CMDER_ROOT/vendor/mintty-colors-solarized/mintty-solarized-dark.sh
 
 | Argument                      | Description                                                                                      | Default                               |
 | ----------------------------- | ----------------------------------------------------------------------------------------------   | ------------------------------------- |
-| /c [user cmder root]          | Enables user bin and config folders for 'Cmder as admin' sessions due to non-shared environment. || not set                               |
+| /c [user cmder root]          | Enables user bin and config folders for 'Cmder as admin' sessions due to non-shared environment. | not set                               |
 | /d                            | Enables debug output.                                                                            | not set                               |
 | /git_install_root [file path] | User specified Git installation root path.                                                       | '%CMDER_ROOT%\vendor\Git-for-Windows' |
 | /home [home folder]           | User specified folder path to set `%HOME%` environment variable.                                 | '%userprofile%'                       |

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ echo source \$CMDER_ROOT/vendor/mintty-colors-solarized/mintty-solarized-dark.sh
 | /git_install_root [file path] | User specified Git installation root path.  Default: '%CMDER_ROOT%\vendor\Git-for-Windows'                   |
 | /home [home folder]           | User specified folder path to set `%HOME%` environment variable.  Default: '%userprofile%'                   |
 | /svn_ssh [path to ssh.exe]    | Define %SVN_SSH% so we can use git svn with ssh svn repositories.  Default: '%GIT_INSTALL_ROOT%\bin\ssh.exe' |
+| /d                            | Enables debug output.                                                                                      |
 | /v                            | Enables verbose output.                                                                                      |
 
 ### Cmder Shell User Config

--- a/README.md
+++ b/README.md
@@ -11,13 +11,42 @@ Cmder is a **software package** created out of pure frustration over absence of 
 The main advantage of Cmder is portability. It is designed to be totally self-contained with no external dependencies, which makes it great for **USB Sticks** or **cloud storage**. So you can carry your console, aliases and binaries (like wget, curl and git) with you anywhere.
 
 ## Installation
+### Single User Portable Config
 
 1. Download the [latest release](https://github.com/cmderdev/cmder/releases/)
-2. Extract the archive
-3. (optional) Place your own executable files into the `bin` folder to be injected into your PATH. (nb: This path should not be `C:\Program Files` or anywhere else that would require Administrator access for modifying configuration files)
+2. Extract the archive. *Note: This path should not be `C:\Program Files` or anywhere else that would require Administrator access for modifying configuration files*
+3. (optional) Place your own executable files into the `%cmder_root%\bin` folder to be injected into your PATH.
 4. Run Cmder.exe
 
-## Integration
+### Shared Cmder install with Non-Portable Individual User Config
+1. Download the [latest release](https://github.com/cmderdev/cmder/releases/)
+2. Extract the archive to a shared location.
+3. (optional) Place your own executable files into the `%cmder_root%\bin` folder to be injected into your PATH.
+4. (optional) Create `%userprofile%\cmder_config\bin` folder to be injected into individual users PATH.  Default is to auto create this on first run.
+5. (optional) Place your own executable files into the `%userprofile%\cmder_config\bin` folder to be injected into your PATH.
+6. Run Cmder.exe with "/C" command line argument. Example: `cmder.exe /C %userprofile%\cmder_config`
+   * This will create the following directory structure if it is missing.
+
+     ```
+     c:\users\[username]\cmder_config
+     ├───bin
+     └───config
+         └───profile.d
+     ```
+
+* Both the shared install and the individual user config locations can contain a full set of init and profile.d scripts enabling shared config with user overrides.  See below.
+
+## Cmder.exe Command Line Arguments
+
+
+| Argument            | Description                                                             |
+| ------------------- | ----------------------------------------------------------------------- |
+| /C [user_root_path] | Individual user Cmder root folder.  Example: %userprofile%\cmder_config |
+| /SINGLE             | Start Cmder is single mode.                                             |
+| /START [start_path] | Folder path to start in.                                                |
+| /TASK [task_name]   | Task to start after launch.                                             |
+
+## Context Menu Integration
 
 So you've experimented with Cmder a little and want to give it a shot in a more permanent home;
 
@@ -57,16 +86,16 @@ In a file explorer window right click in or on a directory to see "Cmder Here" i
 ### Access to multiple shells in one window using tabs
 You can open multiple tabs each containing one of the following shells:
 
-|Task|Shell|Description|
-|----|-----|-----------|
-|Cmder|cmd.exe|Windows 'cmd.exe' shell enhanced with Git, Git aware prompt, Clink(GNU Readline), and Aliases.|
-|Cmder as Admin|cmd.exe|Administrative Windows 'cmd.exe' Cmder shell.|
-|PowerShell|powershell.exe|Windows PowerShell enhanced with Git and Git aware prompt .|
-|PowerShell as Admin|powershell.exe|Administrative Windows 'powershell.exe' Cmder shell.|
-|Bash|bash.exe|Unix/Linux like bash shell running on Windows.|
-|Bash as Admin|bash.exe|Administrative Unix/Linux like bash shell running on Windows.|
-|Mintty|bash.exe|Unix/Linux like bash shell running on Windows. See below for Mintty configuration differences|
-|Mintty as Admin|bash.exe|Administrative Unix/Linux like bash shell running on Windows. See below for Mintty configuration differences|
+| Task                | Shell          | Description                                                                                                  |
+| ----                | -----          | -----------                                                                                                  |
+| Cmder               | cmd.exe        | Windows 'cmd.exe' shell enhanced with Git, Git aware prompt, Clink(GNU Readline), and Aliases.               |
+| Cmder as Admin      | cmd.exe        | Administrative Windows 'cmd.exe' Cmder shell.                                                                |
+| PowerShell          | powershell.exe | Windows PowerShell enhanced with Git and Git aware prompt .                                                  |
+| PowerShell as Admin | powershell.exe | Administrative Windows 'powershell.exe' Cmder shell.                                                         |
+| Bash                | bash.exe       | Unix/Linux like bash shell running on Windows.                                                               |
+| Bash as Admin       | bash.exe       | Administrative Unix/Linux like bash shell running on Windows.                                                |
+| Mintty              | bash.exe       | Unix/Linux like bash shell running on Windows. See below for Mintty configuration differences                |
+| Mintty as Admin     | bash.exe       | Administrative Unix/Linux like bash shell running on Windows. See below for Mintty configuration differences |
 
 Cmder, PowerShell, and Bash tabs all run on top of the Windows Console API and work as you might expect in Cmder with access to use ConEmu's color schemes, key bindings and other settings defined in the ConEmu Settings dialog.
 
@@ -91,52 +120,42 @@ echo source \$CMDER_ROOT/vendor/mintty-colors-solarized/mintty-solarized-dark.sh
 1. Click either:
   * `1. {cmd::Cmder as Admin}`
   * `2. {cmd::Cmder}`
-1. Change `cmd /k "%ConEmuDir%\..\init.bat"` to `cmd /k ""%ConEmuDir%\..\init.bat" "`.  NOTE: The extra quotes and spacing around `"%ConEmuDir%\..\init.bat"`
-1. Add command line arguments after `"%ConEmuDir%\..\init.bat" `
+1. Add command line argumentswhere specified below:
+
+  *Note: Pay attention to the quotes!*
+
+  ```
+  cmd /s /k ""%ConEmuDir%\..\init.bat" [ADD ARGS HERE]"
+  ```
 
 ##### Command Line Arguments for `init.bat`
 
-```
--a [user alias file path]    File path pointing to user aliases.
-                             Default: '%CMDER_ROOT%\config\user-liases.cmd' 
+| Argument                      | Description                                                                                                  |
+| -------------------           | -----------------------------------------------------------------------                                      |
+| /user_aliases [file path]     | File path pointing to user aliases.  Default: '%CMDER_ROOT%\config\user-liases.cmd'                          |
+| /git_install_root [file path] | User specified Git installation root path.  Default: '%CMDER_ROOT%\vendor\Git-for-Windows'                   |
+| /home [home folder]           | User specified folder path to set `%HOME%` environment variable.  Default: '%userprofile%'                   |
+| /svn_ssh [path to ssh.exe]    | Define %SVN_SSH% so we can use git svn with ssh svn repositories.  Default: '%GIT_INSTALL_ROOT%\bin\ssh.exe' |
+| /v                            | Enables verbose output.                                                                                      |
 
--c [user cmder user root]]   User specified Cmder folder.  Allows for a shared install of Cmder with individual user configuratons.
-                             Default: The location of the Cmder.exe file.
+### Cmder Shell User Config
+Single user portable configuration is possible using the cmder specific shell config files.  Edit the below files to add your own configuration:
 
--d [startup folder]          User specified startup folder.
-                             Default: '%userprofile%'
-
--g [git install root]        User specified Git installation root path.
-                             Default: '%CMDER_ROOT%\vendor\Git for Windows'
-
--h [home folder]             User specified folder path to set `%HOME%` environment variable.
-                             Default: '%userprofile%'
-
--s [path to ssh.exe]         Define %SVN_SSH% so we can use git svn with ssh svn repositories.
-                             Default: '%GIT_INSTALL_ROOT%\bin\ssh.exe'
-
--v                           Enables verbose output.
-```
-
-### Cmder Portable Shell User Config
-User specific configuration is possible using the cmder specific shell config files.  Edit the below files to add your own configuration:
-
-|Shell|Cmder Portable User Config|
-| ------------- |:-------------:|
-|Cmder|%CMDER_ROOT%\config\user-profile.cmd|
-|PowerShell|$ENV:CMDER_ROOT\config\user-profile.ps1|
-|Bash/Mintty|$CMDER_ROOT/config/user-profile.sh|
+| Shell         | Cmder Portable User Config              |
+| ------------- | :-------------:                         |
+| Cmder         | %CMDER_ROOT%\config\user-profile.cmd    |
+| PowerShell    | $ENV:CMDER_ROOT\config\user-profile.ps1 |
+| Bash/Mintty   | $CMDER_ROOT/config/user-profile.sh      |
 
 Note: Bash and Mintty sessions will also source the '$HOME/.bashrc' file if it exists after it sources '$CMDER_ROOT/config/user-profile.sh'.
 
-### Linux like 'profile.d' support for all supported shell types.
 You can write *.cmd|*.bat, *.ps1, and *.sh scripts and just drop them in the %CMDER_ROOT%\config\profile.d folder to add startup config to Cmder.
 
-|Shell|Cmder 'Profile.d' Scripts|
-| ------------- |:-------------:|
-|Cmder|%CMDER_ROOT%\config\profile.d\\*.bat and *.cmd|
-|PowerShell|$ENV:CMDER_ROOT\config\profile.d\\*.ps1|
-|Bash/Mintty|$CMDER_ROOT/config/profile.d/*.sh|
+| Shell         | Cmder 'Profile.d' Scripts                      |
+| ------------- | :-------------:                                |
+| Cmder         | %CMDER_ROOT%\config\profile.d\\*.bat and *.cmd |
+| PowerShell    | $ENV:CMDER_ROOT\config\profile.d\\*.ps1        |
+| Bash/Mintty   | $CMDER_ROOT/config/profile.d/*.sh              |
 
 
 ### Aliases
@@ -176,7 +195,7 @@ To make an alias and/or any other profile settings permanent add it to one of th
 Note: These are loaded in this order by '$ENV:CMDER_ROOT\\vendor\\user-profile.ps1'.  Anyhing stored in '$ENV:CMDER_ROOT' will be a portable setting and will follow cmder to another machine.
 
 * '$ENV:CMDER_ROOT\\config\\profile.d\\\*.ps1'
-* '$ENV:CMDER_ROOT\\config\\user-profile.ps1'
+* '$ENV:CMDER_ROOT\\config\\user-profile.ps2'
 
 ### SSH Agent
 

--- a/README.md
+++ b/README.md
@@ -151,11 +151,11 @@ Note: Bash and Mintty sessions will also source the '$HOME/.bashrc' file if it e
 
 You can write *.cmd|*.bat, *.ps1, and *.sh scripts and just drop them in the %CMDER_ROOT%\config\profile.d folder to add startup config to Cmder.
 
-| Shell         | Cmder 'Profile.d' Scripts                      |
-| ------------- | :-------------:                                |
-| Cmder         | %CMDER_ROOT%\config\profile.d\\*.bat and *.cmd |
-| PowerShell    | $ENV:CMDER_ROOT\config\profile.d\\*.ps1        |
-| Bash/Mintty   | $CMDER_ROOT/config/profile.d/*.sh              |
+| Shell         | Cmder 'Profile.d' Scripts                         |
+| ------------- | :-------------:                                   |
+| Cmder         | %CMDER_ROOT%\\config\\profile.d\\\*.bat and *.cmd |
+| PowerShell    | $ENV:CMDER_ROOT\\config\\profile.d\\\*.ps1        |
+| Bash/Mintty   | $CMDER_ROOT/config/profile.d/*.sh                 |
 
 
 ### Aliases
@@ -195,7 +195,7 @@ To make an alias and/or any other profile settings permanent add it to one of th
 Note: These are loaded in this order by '$ENV:CMDER_ROOT\\vendor\\user-profile.ps1'.  Anyhing stored in '$ENV:CMDER_ROOT' will be a portable setting and will follow cmder to another machine.
 
 * '$ENV:CMDER_ROOT\\config\\profile.d\\\*.ps1'
-* '$ENV:CMDER_ROOT\\config\\user-profile.ps2'
+* '$ENV:CMDER_ROOT\\config\\user-profile.ps1'
 
 ### SSH Agent
 

--- a/README.md
+++ b/README.md
@@ -130,30 +130,31 @@ echo source \$CMDER_ROOT/vendor/mintty-colors-solarized/mintty-solarized-dark.sh
 
 ##### Command Line Arguments for `init.bat`
 
-| Argument                      | Description                                                                                                  |
-| -------------------           | -----------------------------------------------------------------------                                      |
-| /user_aliases [file path]     | File path pointing to user aliases.  Default: '%CMDER_ROOT%\config\user-liases.cmd'                          |
-| /git_install_root [file path] | User specified Git installation root path.  Default: '%CMDER_ROOT%\vendor\Git-for-Windows'                   |
-| /home [home folder]           | User specified folder path to set `%HOME%` environment variable.  Default: '%userprofile%'                   |
-| /svn_ssh [path to ssh.exe]    | Define %SVN_SSH% so we can use git svn with ssh svn repositories.  Default: '%GIT_INSTALL_ROOT%\bin\ssh.exe' |
-| /d                            | Enables debug output.                                                                                      |
-| /v                            | Enables verbose output.                                                                                      |
+| Argument                      | Description                                                                                    | Default                               |
+| ----------------------------- | ---------------------------------------------------------------------------------------------- | ------------------------------------- |
+| /d                            | Enables debug output.                                                                          |                                       |
+| /git_install_root [file path] | User specified Git installation root path.                                                     | '%CMDER_ROOT%\vendor\Git-for-Windows' |
+| /home [home folder]           | User specified folder path to set `%HOME%` environment variable.                               | '%userprofile%'                       |
+| /max_depth [1-5]              | Define max recurse depth when adding to the path for `%cmder_root%\bin` and `%cmder_user_bin%` | 1                                     |
+| /svn_ssh [path to ssh.exe]    | Define %SVN_SSH% so we can use git svn with ssh svn repositories.                              | '%GIT_INSTALL_ROOT%\bin\ssh.exe'      |
+| /user_aliases [file path]     | File path pointing to user aliases.                                                            | '%CMDER_ROOT%\config\user-liases.cmd' |
+| /v                            | Enables verbose output.                                                                        |                                       |
 
 ### Cmder Shell User Config
 Single user portable configuration is possible using the cmder specific shell config files.  Edit the below files to add your own configuration:
 
-| Shell         | Cmder Portable User Config              |
-| ------------- | :-------------:                         |
-| Cmder         | %CMDER_ROOT%\config\user-profile.cmd    |
-| PowerShell    | $ENV:CMDER_ROOT\config\user-profile.ps1 |
-| Bash/Mintty   | $CMDER_ROOT/config/user-profile.sh      |
+| Shell         | Cmder Portable User Config                |
+| ------------- | ----------------------------------------- |
+| Cmder         | %CMDER_ROOT%\\config\\user-profile.cmd    |
+| PowerShell    | $ENV:CMDER_ROOT\\config\\user-profile.ps1 |
+| Bash/Mintty   | $CMDER_ROOT/config/user-profile.sh        |
 
 Note: Bash and Mintty sessions will also source the '$HOME/.bashrc' file if it exists after it sources '$CMDER_ROOT/config/user-profile.sh'.
 
 You can write *.cmd|*.bat, *.ps1, and *.sh scripts and just drop them in the %CMDER_ROOT%\config\profile.d folder to add startup config to Cmder.
 
 | Shell         | Cmder 'Profile.d' Scripts                         |
-| ------------- | :-------------:                                   |
+| ------------- | --------------------------------------------------|
 | Cmder         | %CMDER_ROOT%\\config\\profile.d\\\*.bat and *.cmd |
 | PowerShell    | $ENV:CMDER_ROOT\\config\\profile.d\\\*.ps1        |
 | Bash/Mintty   | $CMDER_ROOT/config/profile.d/*.sh                 |

--- a/README.md
+++ b/README.md
@@ -85,6 +85,39 @@ cd mintty-colors-solarized/
 echo source \$CMDER_ROOT/vendor/mintty-colors-solarized/mintty-solarized-dark.sh>>$CMDER_ROOT/config/user-profile.sh
 ```
 
+### Changing Cmder Default 'cmd.exe' Shell Startup
+
+1. Press <kbd>Win</kbd> + <kbd>Alt</kbd> + <kbd>T</kbd>
+1. Click either:
+  * `1. {cmd::Cmder as Admin}`
+  * `2. {cmd::Cmder}`
+1. Change `cmd /k "%ConEmuDir%\..\init.bat"` to `cmd /k ""%ConEmuDir%\..\init.bat" "`.  NOTE: The extra quotes and spacing around `"%ConEmuDir%\..\init.bat"`
+1. Add command line arguments after `"%ConEmuDir%\..\init.bat" `
+
+##### Command Line Arguments for `init.bat`
+
+```
+-a [user alias file path]    File path pointing to user aliases.
+                             Default: '%CMDER_ROOT%\config\user-liases.cmd' 
+
+-c [user cmder user root]]   User specified Cmder folder.  Allows for a shared install of Cmder with individual user configuratons.
+                             Default: The location of the Cmder.exe file.
+
+-d [startup folder]          User specified startup folder.
+                             Default: '%userprofile%'
+
+-g [git install root]        User specified Git installation root path.
+                             Default: '%CMDER_ROOT%\vendor\Git for Windows'
+
+-h [home folder]             User specified folder path to set `%HOME%` environment variable.
+                             Default: '%userprofile%'
+
+-s [path to ssh.exe]         Define %SVN_SSH% so we can use git svn with ssh svn repositories.
+                             Default: '%GIT_INSTALL_ROOT%\bin\ssh.exe'
+
+-v                           Enables verbose output.
+```
+
 ### Cmder Portable Shell User Config
 User specific configuration is possible using the cmder specific shell config files.  Edit the below files to add your own configuration:
 

--- a/README.md
+++ b/README.md
@@ -130,15 +130,16 @@ echo source \$CMDER_ROOT/vendor/mintty-colors-solarized/mintty-solarized-dark.sh
 
 ##### Command Line Arguments for `init.bat`
 
-| Argument                      | Description                                                                                    | Default                               |
-| ----------------------------- | ---------------------------------------------------------------------------------------------- | ------------------------------------- |
-| /d                            | Enables debug output.                                                                          |                                       |
-| /git_install_root [file path] | User specified Git installation root path.                                                     | '%CMDER_ROOT%\vendor\Git-for-Windows' |
-| /home [home folder]           | User specified folder path to set `%HOME%` environment variable.                               | '%userprofile%'                       |
-| /max_depth [1-5]              | Define max recurse depth when adding to the path for `%cmder_root%\bin` and `%cmder_user_bin%` | 1                                     |
-| /svn_ssh [path to ssh.exe]    | Define %SVN_SSH% so we can use git svn with ssh svn repositories.                              | '%GIT_INSTALL_ROOT%\bin\ssh.exe'      |
-| /user_aliases [file path]     | File path pointing to user aliases.                                                            | '%CMDER_ROOT%\config\user-liases.cmd' |
-| /v                            | Enables verbose output.                                                                        |                                       |
+| Argument                      | Description                                                                                      | Default                               |
+| ----------------------------- | ----------------------------------------------------------------------------------------------   | ------------------------------------- |
+| /c [user cmder root]          | Enables user bin and config folders for 'Cmder as admin' sessions due to non-shared environment. || not set                               |
+| /d                            | Enables debug output.                                                                            | not set                               |
+| /git_install_root [file path] | User specified Git installation root path.                                                       | '%CMDER_ROOT%\vendor\Git-for-Windows' |
+| /home [home folder]           | User specified folder path to set `%HOME%` environment variable.                                 | '%userprofile%'                       |
+| /max_depth [1-5]              | Define max recurse depth when adding to the path for `%cmder_root%\bin` and `%cmder_user_bin%`   | 1                                     |
+| /svn_ssh [path to ssh.exe]    | Define %SVN_SSH% so we can use git svn with ssh svn repositories.                                | '%GIT_INSTALL_ROOT%\bin\ssh.exe'      |
+| /user_aliases [file path]     | File path pointing to user aliases.                                                              | '%CMDER_ROOT%\config\user-liases.cmd' |
+| /v                            | Enables verbose output.                                                                          | not set                               |
 
 ### Cmder Shell User Config
 Single user portable configuration is possible using the cmder specific shell config files.  Edit the below files to add your own configuration:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ cd mintty-colors-solarized/
 echo source \$CMDER_ROOT/vendor/mintty-colors-solarized/mintty-solarized-dark.sh>>$CMDER_ROOT/config/user-profile.sh
 ```
 
-### Changing Cmder Default 'cmd.exe' Shell Startup
+### Changing Cmder Default 'cmd.exe' Shell Startup Behaviour Using Task Arguments
 
 1. Press <kbd>Win</kbd> + <kbd>Alt</kbd> + <kbd>T</kbd>
 1. Click either:

--- a/config/ConEmu.xml
+++ b/config/ConEmu.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <key name="Software">
 	<key name="ConEmu">
-		<key name=".Vanilla" modified="2015-11-24 14:43:35" build="151119">
+		<key name=".Vanilla" modified="2018-02-22 06:02:11" build="171109">
 			<value name="ColorTable00" type="dword" data="00222827"/>
 			<value name="ColorTable01" type="dword" data="009e5401"/>
 			<value name="ColorTable02" type="dword" data="0004aa74"/>
@@ -101,12 +101,12 @@
 			<value name="FontName" type="string" data="Consolas"/>
 			<value name="FontName2" type="string" data="Lucida Console"/>
 			<value name="FontAutoSize" type="hex" data="00"/>
-			<value name="FontSize" type="dword" data="00000010"/>
-			<value name="FontSizeX" type="dword" data="00000000"/>
-			<value name="FontSizeX2" type="dword" data="00000000"/>
-			<value name="FontSizeX3" type="dword" data="00000000"/>
+			<value name="FontSize" type="ulong" data="16"/>
+			<value name="FontSizeX" type="ulong" data="0"/>
+			<value name="FontSizeX2" type="ulong" data="0"/>
+			<value name="FontSizeX3" type="ulong" data="0"/>
 			<value name="FontCharSet" type="hex" data="00"/>
-			<value name="Anti-aliasing" type="dword" data="00000006"/>
+			<value name="Anti-aliasing" type="ulong" data="6"/>
 			<value name="FontBold" type="hex" data="00"/>
 			<value name="FontItalic" type="hex" data="00"/>
 			<value name="Monospace" type="hex" data="01"/>
@@ -123,29 +123,29 @@
 			<value name="ColorKeyTransparent" type="hex" data="00"/>
 			<value name="ColorKeyValue" type="dword" data="00010101"/>
 			<value name="UseCurrentSizePos" type="hex" data="01"/>
-			<value name="WindowMode" type="dword" data="0000051f"/>
+			<value name="WindowMode" type="dword" data="00000520"/>
 			<value name="ConWnd Width" type="dword" data="00000078"/>
 			<value name="ConWnd Height" type="dword" data="0000001e"/>
 			<value name="Cascaded" type="hex" data="01"/>
-			<value name="ConWnd X" type="dword" data="000001f4"/>
-			<value name="ConWnd Y" type="dword" data="000001f4"/>
-			<value name="16bit Height" type="dword" data="00000000"/>
+			<value name="ConWnd X" type="long" data="500"/>
+			<value name="ConWnd Y" type="long" data="500"/>
+			<value name="16bit Height" type="ulong" data="0"/>
 			<value name="AutoSaveSizePos" type="hex" data="01"/>
 			<value name="IntegralSize" type="hex" data="00"/>
 			<value name="QuakeStyle" type="hex" data="00"/>
-			<value name="QuakeAnimation" type="dword" data="0000012c"/>
+			<value name="QuakeAnimation" type="ulong" data="300"/>
 			<value name="HideCaption" type="hex" data="00"/>
 			<value name="HideChildCaption" type="hex" data="01"/>
 			<value name="FocusInChildWindows" type="hex" data="01"/>
 			<value name="HideCaptionAlways" type="hex" data="00"/>
 			<value name="HideCaptionAlwaysFrame" type="hex" data="00"/>
-			<value name="HideCaptionAlwaysDelay" type="dword" data="000007d0"/>
-			<value name="HideCaptionAlwaysDisappear" type="dword" data="000007d0"/>
+			<value name="HideCaptionAlwaysDelay" type="ulong" data="2000"/>
+			<value name="HideCaptionAlwaysDisappear" type="ulong" data="2000"/>
 			<value name="DownShowHiddenMessage" type="hex" data="00"/>
 			<value name="ConsoleFontName" type="string" data="Lucida Console"/>
-			<value name="ConsoleFontWidth" type="dword" data="00000003"/>
-			<value name="ConsoleFontHeight" type="dword" data="00000005"/>
-			<value name="DefaultBufferHeight" type="dword" data="000003e8"/>
+			<value name="ConsoleFontWidth" type="long" data="3"/>
+			<value name="ConsoleFontHeight" type="long" data="5"/>
+			<value name="DefaultBufferHeight" type="long" data="1000"/>
 			<value name="AutoBufferHeight" type="hex" data="01"/>
 			<value name="CmdOutputCP" type="dword" data="00000000"/>
 			<value name="ComSpec.Type" type="hex" data="00"/>
@@ -167,7 +167,7 @@
 			<value name="CTS.MBtnAction" type="hex" data="00"/>
 			<value name="CTS.ColorIndex" type="hex" data="e0"/>
 			<value name="ClipboardConfirmEnter" type="hex" data="01"/>
-			<value name="ClipboardConfirmLonger" type="dword" data="000000c8"/>
+			<value name="ClipboardConfirmLonger" type="ulong" data="200"/>
 			<value name="FarGotoEditorOpt" type="hex" data="01"/>
 			<value name="FarGotoEditorPath" type="string" data="far.exe /e%1:%2 &quot;%3&quot;"/>
 			<value name="FixFarBorders" type="hex" data="01"/>
@@ -198,7 +198,7 @@
 			<value name="MouseSkipActivation" type="hex" data="01"/>
 			<value name="MouseSkipMoving" type="hex" data="01"/>
 			<value name="FarHourglass" type="hex" data="01"/>
-			<value name="FarHourglassDelay" type="dword" data="000001f4"/>
+			<value name="FarHourglassDelay" type="ulong" data="500"/>
 			<value name="Dnd" type="hex" data="01"/>
 			<value name="DndDrop" type="hex" data="01"/>
 			<value name="DefCopy" type="hex" data="01"/>
@@ -212,8 +212,8 @@
 			<value name="StatusBar.Show" type="hex" data="00"/>
 			<value name="StatusBar.Flags" type="dword" data="00000002"/>
 			<value name="StatusFontFace" type="string" data="Tahoma"/>
-			<value name="StatusFontCharSet" type="dword" data="00000000"/>
-			<value name="StatusFontHeight" type="dword" data="0000000e"/>
+			<value name="StatusFontCharSet" type="ulong" data="0"/>
+			<value name="StatusFontHeight" type="long" data="14"/>
 			<value name="StatusBar.Color.Back" type="dword" data="00404040"/>
 			<value name="StatusBar.Color.Light" type="dword" data="00ffffff"/>
 			<value name="StatusBar.Color.Dark" type="dword" data="00a0a0a0"/>
@@ -254,34 +254,34 @@
 			<value name="TabSelf" type="hex" data="01"/>
 			<value name="TabLazy" type="hex" data="01"/>
 			<value name="TabRecent" type="hex" data="00"/>
-			<value name="TabDblClick" type="dword" data="00000001"/>
+			<value name="TabDblClick" type="ulong" data="1"/>
 			<value name="TabsOnTaskBar" type="hex" data="02"/>
 			<value name="TaskBarOverlay" type="hex" data="01"/>
 			<value name="TabCloseMacro" type="string" data=""/>
 			<value name="TabFontFace" type="string" data="Segoe UI"/>
-			<value name="TabFontCharSet" type="dword" data="00000000"/>
-			<value name="TabFontHeight" type="dword" data="00000010"/>
+			<value name="TabFontCharSet" type="ulong" data="0"/>
+			<value name="TabFontHeight" type="long" data="16"/>
 			<value name="SaveAllEditors" type="string" data=""/>
-			<value name="ToolbarAddSpace" type="dword" data="00000000"/>
+			<value name="ToolbarAddSpace" type="long" data="0"/>
 			<value name="TabConsole" type="string" data="     %n     "/>
 			<value name="TabSkipWords" type="string" data="Administrator:|Администратор:"/>
 			<value name="TabPanels" type="string" data="&lt;%c&gt; %s"/>
 			<value name="TabEditor" type="string" data="&lt;%c.%i&gt;{%s}"/>
 			<value name="TabEditorModified" type="string" data="&lt;%c.%i&gt;[%s] *"/>
 			<value name="TabViewer" type="string" data="&lt;%c.%i&gt;[%s]"/>
-			<value name="TabLenMax" type="dword" data="00000014"/>
+			<value name="TabLenMax" type="ulong" data="20"/>
 			<value name="AdminTitleSuffix" type="string" data=" (Admin)"/>
 			<value name="AdminShowShield" type="hex" data="01"/>
 			<value name="HideInactiveConsoleTabs" type="hex" data="00"/>
 			<value name="ShowFarWindows" type="hex" data="01"/>
 			<value name="TryToCenter" type="hex" data="01"/>
-			<value name="CenterConsolePad" type="dword" data="00000008"/>
+			<value name="CenterConsolePad" type="ulong" data="8"/>
 			<value name="ShowScrollbar" type="hex" data="02"/>
-			<value name="ScrollBarAppearDelay" type="dword" data="00000064"/>
-			<value name="ScrollBarDisappearDelay" type="dword" data="000003e8"/>
-			<value name="IconID" type="dword" data="00000001"/>
-			<value name="MainTimerElapse" type="dword" data="0000000a"/>
-			<value name="MainTimerInactiveElapse" type="dword" data="000003e8"/>
+			<value name="ScrollBarAppearDelay" type="ulong" data="100"/>
+			<value name="ScrollBarDisappearDelay" type="ulong" data="1000"/>
+			<value name="IconID" type="ulong" data="1"/>
+			<value name="MainTimerElapse" type="ulong" data="10"/>
+			<value name="MainTimerInactiveElapse" type="ulong" data="1000"/>
 			<value name="AffinityMask" type="dword" data="00000000"/>
 			<value name="SkipFocusEvents" type="hex" data="00"/>
 			<value name="MonitorConsoleLang" type="hex" data="03"/>
@@ -297,32 +297,32 @@
 			<value name="FindMatchWholeWords" type="hex" data="00"/>
 			<value name="FindTransparent" type="hex" data="01"/>
 			<value name="PanView.BackColor" type="dword" data="30ffffff"/>
-			<value name="PanView.PFrame" type="dword" data="00000001"/>
+			<value name="PanView.PFrame" type="long" data="1"/>
 			<value name="PanView.PFrameColor" type="dword" data="28808080"/>
-			<value name="PanView.SFrame" type="dword" data="00000001"/>
+			<value name="PanView.SFrame" type="long" data="1"/>
 			<value name="PanView.SFrameColor" type="dword" data="07c0c0c0"/>
-			<value name="PanView.Thumbs.ImgSize" type="dword" data="00000060"/>
-			<value name="PanView.Thumbs.SpaceX1" type="dword" data="00000001"/>
-			<value name="PanView.Thumbs.SpaceY1" type="dword" data="00000001"/>
-			<value name="PanView.Thumbs.SpaceX2" type="dword" data="00000005"/>
-			<value name="PanView.Thumbs.SpaceY2" type="dword" data="00000014"/>
-			<value name="PanView.Thumbs.LabelSpacing" type="dword" data="00000002"/>
-			<value name="PanView.Thumbs.LabelPadding" type="dword" data="00000000"/>
+			<value name="PanView.Thumbs.ImgSize" type="long" data="96"/>
+			<value name="PanView.Thumbs.SpaceX1" type="long" data="1"/>
+			<value name="PanView.Thumbs.SpaceY1" type="long" data="1"/>
+			<value name="PanView.Thumbs.SpaceX2" type="long" data="5"/>
+			<value name="PanView.Thumbs.SpaceY2" type="long" data="20"/>
+			<value name="PanView.Thumbs.LabelSpacing" type="long" data="2"/>
+			<value name="PanView.Thumbs.LabelPadding" type="long" data="0"/>
 			<value name="PanView.Thumbs.FontName" type="string" data="Tahoma"/>
-			<value name="PanView.Thumbs.FontHeight" type="dword" data="0000000e"/>
-			<value name="PanView.Tiles.ImgSize" type="dword" data="00000030"/>
-			<value name="PanView.Tiles.SpaceX1" type="dword" data="00000004"/>
-			<value name="PanView.Tiles.SpaceY1" type="dword" data="00000004"/>
-			<value name="PanView.Tiles.SpaceX2" type="dword" data="000000ac"/>
-			<value name="PanView.Tiles.SpaceY2" type="dword" data="00000004"/>
-			<value name="PanView.Tiles.LabelSpacing" type="dword" data="00000004"/>
-			<value name="PanView.Tiles.LabelPadding" type="dword" data="00000001"/>
+			<value name="PanView.Thumbs.FontHeight" type="long" data="14"/>
+			<value name="PanView.Tiles.ImgSize" type="long" data="48"/>
+			<value name="PanView.Tiles.SpaceX1" type="long" data="4"/>
+			<value name="PanView.Tiles.SpaceY1" type="long" data="4"/>
+			<value name="PanView.Tiles.SpaceX2" type="long" data="172"/>
+			<value name="PanView.Tiles.SpaceY2" type="long" data="4"/>
+			<value name="PanView.Tiles.LabelSpacing" type="long" data="4"/>
+			<value name="PanView.Tiles.LabelPadding" type="long" data="1"/>
 			<value name="PanView.Tiles.FontName" type="string" data="Tahoma"/>
-			<value name="PanView.Tiles.FontHeight" type="dword" data="0000000e"/>
+			<value name="PanView.Tiles.FontHeight" type="long" data="14"/>
 			<value name="PanView.LoadPreviews" type="hex" data="03"/>
 			<value name="PanView.LoadFolders" type="hex" data="01"/>
-			<value name="PanView.LoadTimeout" type="dword" data="0000000f"/>
-			<value name="PanView.MaxZoom" type="dword" data="00000258"/>
+			<value name="PanView.LoadTimeout" type="ulong" data="15"/>
+			<value name="PanView.MaxZoom" type="ulong" data="600"/>
 			<value name="PanView.UsePicView2" type="hex" data="01"/>
 			<value name="PanView.RestoreOnStartup" type="hex" data="00"/>
 			<value name="Update.VerLocation" type="string" data=""/>
@@ -483,89 +483,89 @@
 			<value name="DndLKey" type="hex" data="00"/>
 			<value name="DndRKey" type="hex" data="a2"/>
 			<value name="WndDragKey" type="dword" data="00121101"/>
-			<key name="Tasks" modified="2015-11-24 14:43:35" build="151119">
-				<value name="Count" type="dword" data="00000008"/>
-				<key name="Task1" modified="2015-11-24 14:49:10" build="151119">
+			<key name="Tasks" modified="2018-02-22 06:02:12" build="171109">
+				<value name="Count" type="long" data="8"/>
+				<key name="Task1" modified="2018-02-22 06:02:12" build="171109">
 					<value name="Name" type="string" data="{cmd::Cmder as Admin}"/>
 					<value name="GuiArgs" type="string" data=" /icon &quot;%CMDER_ROOT%\icons\cmder.ico&quot;"/>
-					<value name="Cmd1" type="string" data="*cmd /k &quot;%ConEmuDir%\..\init.bat&quot;"/>
-					<value name="Active" type="dword" data="00000000"/>
-					<value name="Count" type="dword" data="00000001"/>
+					<value name="Cmd1" type="string" data="*cmd /k &quot;&quot;%ConEmuDir%\..\init.bat&quot; &quot;"/>
+					<value name="Active" type="long" data="0"/>
+					<value name="Count" type="long" data="1"/>
 					<value name="Hotkey" type="dword" data="00000000"/>
 					<value name="Flags" type="dword" data="00000000"/>
 				</key>
-				<key name="Task2" modified="2015-11-24 14:49:10" build="151119">
+				<key name="Task2" modified="2018-02-22 06:05:13" build="171109">
 					<value name="Name" type="string" data="{cmd::Cmder}"/>
 					<value name="GuiArgs" type="string" data=" /icon &quot;%CMDER_ROOT%\icons\cmder.ico&quot;"/>
-					<value name="Cmd1" type="string" data="cmd /k &quot;%ConEmuDir%\..\init.bat&quot;"/>
-					<value name="Active" type="dword" data="00000000"/>
-					<value name="Count" type="dword" data="00000001"/>
+					<value name="Cmd1" type="string" data="cmd /k &quot;&quot;%ConEmuDir%\..\init.bat&quot; &quot;"/>
+					<value name="Active" type="long" data="0"/>
+					<value name="Count" type="long" data="1"/>
 					<value name="Hotkey" type="dword" data="00000000"/>
 					<value name="Flags" type="dword" data="00000000"/>
 				</key>
-				<key name="Task3" modified="2015-11-24 14:49:10" build="151119">
+				<key name="Task3" modified="2018-02-22 06:05:13" build="171109">
 					<value name="Name" type="string" data="{Powershell::PowerShell as Admin}"/>
 					<value name="Hotkey" type="dword" data="00000000"/>
 					<value name="GuiArgs" type="string" data=" /icon &quot;%CMDER_ROOT%\icons\cmder.ico&quot;"/>
 					<value name="Cmd1" type="string" data="*PowerShell -ExecutionPolicy Bypass -NoLogo -NoProfile -NoExit -Command &quot;Invoke-Expression '. ''%ConEmuDir%\..\profile.ps1'''&quot;"/>
-					<value name="Active" type="dword" data="00000000"/>
-					<value name="Count" type="dword" data="00000001"/>
+					<value name="Active" type="long" data="0"/>
+					<value name="Count" type="long" data="1"/>
 					<value name="Flags" type="dword" data="00000000"/>
 				</key>
-				<key name="Task4" modified="2015-11-24 14:49:10" build="151119">
+				<key name="Task4" modified="2018-02-22 06:05:13" build="171109">
 					<value name="Name" type="string" data="{Powershell::Powershell}"/>
 					<value name="Hotkey" type="dword" data="00000000"/>
 					<value name="GuiArgs" type="string" data=" /icon &quot;%CMDER_ROOT%\icons\cmder.ico&quot;"/>
 					<value name="Cmd1" type="string" data="PowerShell -ExecutionPolicy Bypass -NoLogo -NoProfile -NoExit -Command &quot;Invoke-Expression '. ''%ConEmuDir%\..\profile.ps1'''&quot;"/>
 					<value name="Cmd2" type="string" data="%CMDER_ROOT%\vendor\git-for-windows\git-bash.exe"/>
-					<value name="Active" type="dword" data="00000000"/>
-					<value name="Count" type="dword" data="00000001"/>
+					<value name="Active" type="long" data="0"/>
+					<value name="Count" type="long" data="1"/>
 					<value name="Flags" type="dword" data="00000000"/>
 				</key>
-				<key name="Task5" modified="2015-11-24 14:49:10" build="151119">
+				<key name="Task5" modified="2018-02-22 06:05:13" build="171109">
 					<value name="Name" type="string" data="{bash::mintty as Admin}"/>
 					<value name="Flags" type="dword" data="00000000"/>
 					<value name="Hotkey" type="dword" data="00000000"/>
 					<value name="GuiArgs" type="string" data="/icon &quot;%ConEmuDir%\..\git-for-windows\usr\share\git\git-for-windows.ico&quot;"/>
 					<value name="Cmd1" type="string" data="*%ConEmuDir%\..\git-for-windows\usr\bin\mintty.exe /bin/bash -l"/>
-					<value name="Active" type="dword" data="00000000"/>
-					<value name="Count" type="dword" data="00000001"/>
+					<value name="Active" type="long" data="0"/>
+					<value name="Count" type="long" data="1"/>
 				</key>
-				<key name="Task6" modified="2015-11-24 14:49:10" build="151119">
+				<key name="Task6" modified="2018-02-22 06:05:13" build="171109">
 					<value name="Name" type="string" data="{bash::mintty}"/>
 					<value name="Flags" type="dword" data="00000000"/>
 					<value name="Hotkey" type="dword" data="00000000"/>
 					<value name="GuiArgs" type="string" data="/icon &quot;%ConEmuDir%\..\git-for-windows\usr\share\git\git-for-windows.ico&quot;"/>
 					<value name="Cmd1" type="string" data="%ConEmuDir%\..\git-for-windows\usr\bin\mintty.exe /bin/bash -l"/>
-					<value name="Active" type="dword" data="00000000"/>
-					<value name="Count" type="dword" data="00000001"/>
+					<value name="Active" type="long" data="0"/>
+					<value name="Count" type="long" data="1"/>
 					<value name="Cmd2" type="string" data="%CMDER_ROOT%vendor\git-for-windows\usr\bin\mintty.exe /bin/bash -l"/>
 				</key>
-				<key name="Task7" modified="2015-11-24 14:49:10" build="151119">
+				<key name="Task7" modified="2018-02-22 06:05:13" build="171109">
 					<value name="Name" type="string" data="{bash::bash as Admin}"/>
 					<value name="Flags" type="dword" data="00000000"/>
 					<value name="Hotkey" type="dword" data="00000000"/>
 					<value name="GuiArgs" type="string" data=" /icon &quot;%CMDER_ROOT%\icons\cmder.ico&quot;"/>
-					<value name="Active" type="dword" data="00000000"/>
-					<value name="Count" type="dword" data="00000001"/>
+					<value name="Active" type="long" data="0"/>
+					<value name="Count" type="long" data="1"/>
 					<value name="Cmd1" type="string" data="*cmd /c &quot;%ConEmuDir%\..\git-for-windows\bin\bash --login -i&quot;"/>
 				</key>
-				<key name="Task8" modified="2015-11-24 14:49:10" build="151119">
+				<key name="Task8" modified="2018-02-22 06:05:13" build="171109">
 					<value name="Name" type="string" data="{bash::bash}"/>
 					<value name="Flags" type="dword" data="00000000"/>
 					<value name="Hotkey" type="dword" data="00000000"/>
 					<value name="GuiArgs" type="string" data=" /icon &quot;%CMDER_ROOT%\icons\cmder.ico&quot;"/>
 					<value name="Cmd1" type="string" data="cmd /c &quot;%ConEmuDir%\..\git-for-windows\bin\bash --login -i&quot;"/>
-					<value name="Active" type="dword" data="00000000"/>
-					<value name="Count" type="dword" data="00000001"/>
+					<value name="Active" type="long" data="0"/>
+					<value name="Count" type="long" data="1"/>
 				</key>
 			</key>
 
-			<key name="Apps" modified="2015-11-24 14:49:10" build="151119">
-				<value name="Count" type="dword" data="00000000"/>
+			<key name="Apps" modified="2018-02-22 06:05:13" build="171109">
+				<value name="Count" type="long" data="0"/>
 			</key>
-			<key name="Colors" modified="2015-11-24 14:49:10" build="151119">
-				<key name="Palette1" modified="2015-11-24 14:49:10" build="151119">
+			<key name="Colors" modified="2018-02-22 06:05:13" build="171109">
+				<key name="Palette1" modified="2018-02-22 06:05:13" build="171109">
 					<value name="Name" type="string" data="Monokai"/>
 					<value name="ExtendColors" type="hex" data="00"/>
 					<value name="ExtendColorIdx" type="hex" data="0e"/>
@@ -606,11 +606,11 @@
 					<value name="ColorTable30" type="dword" data="0000ffff"/>
 					<value name="ColorTable31" type="dword" data="00ffffff"/>
 				</key>
-				<value name="Count" type="dword" data="00000001"/>
+				<value name="Count" type="long" data="1"/>
 			</key>
 			<value name="OneTabPerGroup" type="hex" data="00"/>
 			<value name="ActivateSplitMouseOver" type="hex" data="01"/>
-			<value name="TabBtnDblClick" type="dword" data="00000000"/>
+			<value name="TabBtnDblClick" type="ulong" data="0"/>
 			<value name="ConsoleExceptionHandler" type="hex" data="00"/>
 			<value name="SaveCmdHistory" type="hex" data="00"/>
 			<value name="CTS.IBeam" type="hex" data="01"/>
@@ -664,9 +664,9 @@
 			<value name="StatusBar.Hide.WVDC" type="hex" data="01"/>
 			<value name="StatusBar.Hide.Zoom" type="hex" data="01"/>
 			<value name="StatusBar.Hide.Dpi" type="hex" data="01"/>
-			<value name="TabFlashChanged" type="dword" data="00000008"/>
+			<value name="TabFlashChanged" type="long" data="8"/>
 			<value name="TabModifiedSuffix" type="string" data="[*]"/>
-			<key name="HotKeys" modified="2015-11-24 14:43:35" build="151119">
+			<key name="HotKeys" modified="2018-02-22 06:02:12" build="171109">
 				<value name="KeyMacroVersion" type="hex" data="02"/>
 				<value name="Multi.Modifier" type="dword" data="00000011"/>
 				<value name="Multi.ArrowsModifier" type="dword" data="0000005b"/>
@@ -847,16 +847,51 @@
 				<value name="Key.DebugProcess" type="dword" data="00105b44"/>
 				<value name="Key.DumpProcess" type="dword" data="00000000"/>
 				<value name="Key.DumpTree" type="dword" data="00000000"/>
+				<value name="Multi.SplitSwap" type="dword" data="00125d58"/>
+				<value name="Multi.SplitSwapU" type="dword" data="00125d26"/>
+				<value name="Multi.SplitSwapD" type="dword" data="00125d28"/>
+				<value name="Multi.SplitSwapL" type="dword" data="00125d25"/>
+				<value name="Multi.SplitSwapR" type="dword" data="00125d27"/>
+				<value name="Multi.GroupInputAll" type="dword" data="00105d47"/>
+				<value name="Multi.GroupInputKey" type="dword" data="00125d47"/>
+				<value name="Key.AltNumpad" type="dword" data="00000000"/>
+				<value name="Key.JumpActiveMonitor" type="dword" data="00000000"/>
+				<value name="Key.BufPrUp" type="dword" data="00121121"/>
+				<value name="Key.BufPrDn" type="dword" data="00121122"/>
+				<value name="Key.ResetTerm" type="dword" data="00000000"/>
 			</key>
-			<value name="StartCreateDelay" type="dword" data="00000064"/>
+			<value name="StartCreateDelay" type="ulong" data="100"/>
 			<value name="DefaultTerminalDebugLog" type="hex" data="00"/>
-			<value name="LastMonitor" type="string" data="0,0,1920,1020"/>
+			<value name="LastMonitor" type="string" data="0,0,1440,1050"/>
 			<value name="Restore2ActiveMon" type="hex" data="00"/>
 			<value name="DownShowExOnTopMessage" type="hex" data="00"/>
-			<value name="EnvironmentSet" type="multi"/>
+			<value name="EnvironmentSet" type="multi">
+				<line data="set PATH=%ConEmuBaseDir%\Scripts;%PATH%"/>
+			</value>
 			<value name="Update.InetTool" type="hex" data="00"/>
 			<value name="Update.InetToolCmd" type="string" data=""/>
 			<value name="SuppressBells" type="hex" data="01"/>
+			<value name="ClipboardAllLinesPosix" type="hex" data="00"/>
+			<value name="ClipboardFirstLinePosix" type="hex" data="00"/>
+			<value name="VividColors" type="hex" data="01"/>
+			<value name="AnsiExecution" type="hex" data="01"/>
+			<value name="AnsiAllowedCommands" type="multi">
+				<line data="cmd -cur_console:R /cGitShowBranch.cmd"/>
+			</value>
+			<value name="KillSshAgent" type="hex" data="01"/>
+			<value name="ProcessCtrlZ" type="hex" data="00"/>
+			<value name="JumpListAutoUpdate" type="hex" data="01"/>
+			<value name="CompressLongStrings" type="hex" data="01"/>
+			<value name="DynamicBufferHeight" type="hex" data="01"/>
+			<value name="CTS.ResetOnRelease" type="hex" data="00"/>
+			<value name="CTS.EraseBeforeReset" type="hex" data="01"/>
+			<value name="Anti-aliasing2" type="hex" data="00"/>
+			<value name="UseAltGrayPlus" type="hex" data="01"/>
+			<value name="MouseDragWindow" type="hex" data="01"/>
+			<value name="DebugLog" type="hex" data="00"/>
+			<value name="StatusBar.Hide.TMode" type="hex" data="01"/>
+			<value name="StatusBar.Hide.RMode" type="hex" data="01"/>
+			<value name="StatusBar.Hide.CellI" type="hex" data="01"/>
 		</key>
 	</key>
 </key>

--- a/launcher/CmderLauncher.vcxproj
+++ b/launcher/CmderLauncher.vcxproj
@@ -53,7 +53,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Link>

--- a/launcher/CmderLauncher.vcxproj
+++ b/launcher/CmderLauncher.vcxproj
@@ -53,13 +53,16 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_USING_V110_SDK71_;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>

--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -386,11 +386,11 @@ int APIENTRY _tWinMain(_In_ HINSTANCE hInstance,
 				i++;
 			}
 		}
-		else
-		{
-			MessageBox(NULL, L"Unrecognized parameter.\n\nValid options:\n  /C <path>\n  /START <path>\n  /SINGLE <path>\n  /TASK <name>\n /REGISTER [USER/ALL]\n  /UNREGISTER [USER/ALL]", MB_TITLE, MB_OK);
-			return 1;
-		}
+		// else
+		// {
+		// 	MessageBox(NULL, L"Unrecognized parameter.\n\nValid options:\n  /C <path>\n  /START <path>\n  /SINGLE <path>\n  /TASK <name>\n /REGISTER [USER/ALL]\n  /UNREGISTER [USER/ALL]", MB_TITLE, MB_OK);
+		// 	return 1;
+		// }
 	}
 
 	if ( registerApp == true ) {

--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -3,9 +3,6 @@
 #include <Shlwapi.h>
 #include "resource.h"
 #include <vector>
-#include <cstdlib>
-#include <stdlib.h>
-#include <algorithm>
 #include <shlobj.h>
 
 #pragma comment(lib, "Shlwapi.lib")

--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -380,20 +380,17 @@ cmderOptions GetOption()
 
 		if (_wcsicmp(L"/c", szArgList[i]) == 0)
 		{
-			// TCHAR buff[MAX_PATH];
-			// const DWORD ret = GetEnvironmentVariable(L"USERPROFILE", buff, MAX_PATH);
+			TCHAR userProfile[MAX_PATH];
+			const DWORD ret = GetEnvironmentVariable(L"USERPROFILE", userProfile, MAX_PATH);
 
-			// cmderOptions.cmderCfgRoot = buff;
+			wchar_t cmderCfgRoot[MAX_PATH] = { 0 };
+			PathCombine(cmderCfgRoot, userProfile, L"cmder_cfg");
 
-			if (szArgList[i + 1] != NULL) {
-				// std::wregex base_regex(L"^[a-z]{1}\:{1}\\|\\\\");
-				// std::wsmatch wideMatch;
-				// std::wstring target(szArgList[i + 1]);
+			cmderOptions.cmderCfgRoot = cmderCfgRoot;
 
-				// if (regex_search(target, base_regex)) {
-					cmderOptions.cmderCfgRoot = szArgList[i + 1];
-					i++;
-				// :w
+			if (szArgList[i + 1] != NULL && szArgList[i + 1][0] != '/') {
+				cmderOptions.cmderCfgRoot = szArgList[i + 1];
+				i++;
 			}
 		}
 		else if (_wcsicmp(L"/start", szArgList[i]) == 0)

--- a/vendor/cmder.sh
+++ b/vendor/cmder.sh
@@ -7,6 +7,20 @@
 # Add system specific users customizations to $HOME/.bashrc, these 
 # customizations will not follow Cmder to another machine.
 
+function runProfiled {
+  unset profile_d_scripts
+  pushd "${1}" >/dev/null
+  profile_d_scripts=$(ls *.sh 2>/dev/null)
+
+  if [ ! "x${profile_d_scripts}" = "x" ] ; then
+    for x in ${profile_d_scripts} ; do
+      echo Sourcing "${1}/${x}"...
+      . "${1}/${x}"
+    done
+  fi
+  popd >/dev/null
+}
+
 # We do this for bash as admin sessions since $CMDER_ROOT is not being set
 if [ "$CMDER_ROOT" == "" ] ; then
     case "$ConEmuDir" in *\\*) CMDER_ROOT=$( cd "$(cygpath -u "$ConEmuDir")/../.." ; pwd );; esac
@@ -42,24 +56,28 @@ if [ ! -d "${CMDER_ROOT}/config/profile.d" ] ; then
 fi
 
 if [ -d "${CMDER_ROOT}/config/profile.d" ] ; then
-  unset profile_d_scripts
-  pushd "${CMDER_ROOT}/config/profile.d" >/dev/null
-  profile_d_scripts=$(ls *.sh 2>/dev/null)
+  runProfiled  "${CMDER_ROOT}/config/profile.d"
+fi
 
-  if [ ! "x${profile_d_scripts}" = "x" ] ; then
-    for x in ${profile_d_scripts} ; do
-      # echo Sourcing "${CMDER_ROOT}/config/profile.d/${x}"...
-      . "${CMDER_ROOT}/config/profile.d/${x}"
-    done
-  fi
-  popd >/dev/null
+if [ -d "${CMDER_USER_CONFIG}/profile.d" ] ; then
+  runProfiled  "${CMDER_USER_CONFIG}/profile.d"
 fi
 
 if [ -f "${CMDER_ROOT}/config/user-profile.sh" ] ; then
     . "${CMDER_ROOT}/config/user-profile.sh"
+fi
+
+if [ -f "${CMDER_USER_CONFIG}/user-profile.sh" ] ; then
+    . "${CMDER_USER_CONFIG}/user-profile.sh"
 else
-    echo Creating user startup file: "${CMDER_ROOT}/config/user-profile.sh"
-    cat <<-eof >"${CMDER_ROOT}/config/user-profile.sh"
+    if [ "${CMDER_USER_CONFIG}" != "" ] ; then
+      initialProfile="${CMDER_USER_CONFIG}/user-profile.sh"
+    else
+      initialProfile="${CMDER_ROOT}/config/user-profile.sh"
+    fi
+
+    echo Creating user startup file: "${initialProfile}"
+    cat <<-eof >"${initialProfile}"
 # use this file to run your own startup commands for msys2 bash'
 
 # To add a new vendor to the path, do something like:

--- a/vendor/cmder_exinit
+++ b/vendor/cmder_exinit
@@ -22,6 +22,25 @@
 # # from outside Cmder.
 # CMDER_ROOT=${USERPROFILE}/cmder  # This is not required if launched from Cmder.
 
+function runProfiled {
+  unset profile_d_scripts
+  pushd "${1}" >/dev/null
+
+  if [ ! "x${ZSH_VERSION}" = "x"  ]; then
+    profile_d_scripts=$(ls *.zsh 2>/dev/null)
+  elif [ ! "x${BASH_VERSION}" = "x"  ]; then
+    profile_d_scripts=$(ls *.sh 2>/dev/null)
+  fi
+
+  if [ ! "x${profile_d_scripts}" = "x" ] ; then
+    for x in ${profile_d_scripts} ; do
+      echo Sourcing "${1}/${x}"...
+      . "${1}/${x}"
+    done
+  fi
+  popd >/dev/null
+}
+
 # Check that we haven't already been sourced.
 [[ -z ${CMDER_EXINIT} ]] && CMDER_EXINIT="1" || return
 
@@ -55,28 +74,29 @@ if [ ! "$CMDER_ROOT" = "" ] ; then
   fi
   
   if [ -d "${CMDER_ROOT}/config/profile.d" ] ; then
-    unset profile_d_scripts
-    pushd "${CMDER_ROOT}/config/profile.d" >/dev/null
-    if [ ! "x${ZSH_VERSION}" = "x"  ]; then
-      profile_d_scripts=$(ls *.zsh 2>/dev/null)
-    elif [ ! "x${BASH_VERSION}" = "x"  ]; then
-      profile_d_scripts=$(ls *.sh 2>/dev/null)
-    fi
-  
-    if [ ! "x${profile_d_scripts}" = "x" ] ; then
-      for x in ${profile_d_scripts} ; do
-        # echo Sourcing "${CMDER_ROOT}/config/profile.d/${x}"...
-        . "${CMDER_ROOT}/config/profile.d/${x}"
-      done
-    fi
-    popd >/dev/null
+    runProfiled  "${CMDER_ROOT}/config/profile.d"
   fi
   
+  if [ -d "${CMDER_USER_CONFIG}/profile.d" ] ; then
+    runProfiled  "${CMDER_USER_CONFIG}/profile.d"
+  fi
+
+ 
   if [ -f "${CMDER_ROOT}/config/user-profile.sh" ] ; then
     . "${CMDER_ROOT}/config/user-profile.sh"
+  fi
+  
+  if [ -f "${CMDER_USER_CONFIG}/user-profile.sh" ] ; then
+      . "${CMDER_USER_CONFIG}/user-profile.sh"
   else
-    echo Creating user startup file: "${CMDER_ROOT}/config/user-profile.sh"
-    cat <<-eof >"${CMDER_ROOT}/config/user-profile.sh"
+      if [ "${CMDER_USER_CONFIG}" != "" ] ; then
+        initialProfile="${CMDER_USER_CONFIG}/user-profile.sh"
+      else
+        initialProfile="${CMDER_ROOT}/config/user-profile.sh"
+      fi
+  
+      echo Creating user startup file: "${initialProfile}"
+    cat <<-eof >"${initialProfile}"
 # use this file to run your own startup commands for msys2 bash'
 
 # To add a new vendor to the path, do something like:

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -313,12 +313,10 @@ exit /b
         exit /b -255
     )
 
-    if "%~1" equ "VENDORED" (
-        :: get the git version in the provided directory
-        for /F "tokens=1,2,3 usebackq" %%F in (`"%git_executable%" --version 2^>nul`) do @(
-            set "GIT_VERSION_%~1=%%H"
-            call :verbose-output GIT_VERSION_%~1=%%H
-        )
+    :: get the git version in the provided directory
+    for /F "tokens=1,2,3 usebackq" %%F in (`"%git_executable%" --version 2^>nul`) do @(
+        set "GIT_VERSION_%~1=%%H"
+        call :verbose-output GIT_VERSION_%~1=%%H
     )
 
     :: parse the returned string

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -9,6 +9,7 @@
 :: Use /v command line arg or set to > 0 for verbose output to aid in debugging.
 set verbose-output=0
 set debug-output=0
+set max_depth=1
 
 :: Find root dir
 if not defined CMDER_ROOT (

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -110,7 +110,6 @@ setlocal enabledelayedexpansion
 call :read_version VENDORED "%CMDER_ROOT%\vendor\git-for-windows\cmd"
 
 :: check if git is in path...
-setlocal enabledelayedexpansion
 for /F "delims=" %%F in ('where git.exe 2^>nul') do @(
 
     :: get the absolute path to the user provided git binary
@@ -306,22 +305,26 @@ exit /b
 
     :: set the executable path
     set "git_executable=%~2\git.exe"
+    call :verbose-output git_executable=%git_executable%
 
     :: check if the executable actually exists
     if not exist "%git_executable%" (
-        :: return a negative error code if the executable doesn't exist
+        call :verbose-output "%git_executable%" does not exist!
         exit /b -255
     )
 
-    :: get the git version in the provided directory
-    for /F "delims=" %%F in ('%git_executable% --version 2^>nul') do @(
-        set "GIT_VERSION_%~1=%%F"
+    if "%~1" equ "VENDORED" (
+        :: get the git version in the provided directory
+        for /F "tokens=1,2,3 usebackq" %%F in (`"%git_executable%" --version 2^>nul`) do @(
+            set "GIT_VERSION_%~1=%%H"
+            call :verbose-output GIT_VERSION_%~1=%%H
+        )
     )
 
     :: parse the returned string
+    call :verbose-output Calling :validate_version "%~1" !GIT_VERSION_%~1!
     call :validate_version "%~1" !GIT_VERSION_%~1!
-
-goto :eof
+    exit /b
 
 :parse_version
 
@@ -332,31 +335,15 @@ goto :eof
         set "%~1_PATCH=%%C"
         set "%~1_BUILD=%%D"
     )
-
-goto :eof
+    exit /b
 
 :validate_version
+    :: now parse the version information into the corresponding variables
+    call :parse_version %~1 %~2
 
-    :: check if we have a valid version string
-    if /I "%~2 %~3"=="GIT VERSION" (
-
-        :: now parse the version information into the corresponding variables
-        call :parse_version %~1 %~4
-
-        :: ... and maybe display it, for debugging purposes.
-        call :verbose-output Found Git Version for %~1: !%~1_MAJOR!.!%~1_MINOR!.!%~1_PATCH!.!%~1_BUILD!
-
-    ) else (
-        :: invalid format returned, use the vendored git instead
-        echo Invalid git version at "%git_executable%" detected!
-        call :verbose-output Returned version: %~2 %~3 %~4
-
-        rem or directly call the VENDORED_GIT
-        set test_dir=
-        exit /b -127
-    )
-
-goto :eof
+    :: ... and maybe display it, for debugging purposes.
+    call :verbose-output Found Git Version for %~1: !%~1_MAJOR!.!%~1_MINOR!.!%~1_PATCH!.!%~1_BUILD!
+    exit /b
 
 :compare_versions
 
@@ -381,8 +368,6 @@ goto :eof
 
     :: looks like we have the same versions.
     exit /b 0
-
-goto :eof
 
 :show_error
     echo ERROR: %*

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -178,7 +178,7 @@ call :enhance_path "%CMDER_ROOT%\bin"
 if defined CMDER_USER_BIN (
   call :enhance_path "%CMDER_USER_BIN%"
 )
-call :enhance_path "%CMDER_ROOT%\" append
+call :enhance_path "%CMDER_ROOT%" append
 
 :: Drop *.bat and *.cmd files into "%CMDER_ROOT%\config\profile.d"
 :: to run them at startup.
@@ -420,29 +420,18 @@ exit /b
     set found=0
 
     call :debug-output  :enhance_path - Env Var - find_query=%find_query%
-    if /i "%~2" == "append" (
-        echo "%PATH%" | findstr /I /R ";%find_query%$" >nul
-        if "!ERRORLEVEL!" == "0" set found=1
+    echo "%PATH%"|findstr >nul /I /R ";%find_query%\"$"
+    if "!ERRORLEVEL!" == "0" set found=1
 
-        call :debug-output  :enhance_path - Env Var 1 - found=!found!
-        if "!found!" == "0" (
-            echo "%PATH%" | findstr /I /R ";%find_query%;" >nul
-            if "!ERRORLEVEL!" == "0" set found=1
-            call :debug-output  :enhance_path - Env Var 2 - found=!found!
-        )
-    ) else (
-        echo "%PATH%"|findstr /I /R ";%find_query%" >nul
+    call :debug-output  :enhance_path - Env Var 1 - found=!found!
+    if "!found!" == "0" (
+        echo "%PATH%"|findstr >nul /i /r ";%find_query%;"
         if "!ERRORLEVEL!" == "0" set found=1
-
-        call :debug-output  :enhance_path - Env Var 1 - found=!found!
-        if "!found!" == "0" (
-            echo "%PATH%" | findstr /I /R ";%find_query%;" >nul
-            if "!ERRORLEVEL!" == "0" set found=1
-            call :debug-output  :enhance_path - Env Var 2 - found=!found!
-        )
+        call :debug-output  :enhance_path - Env Var 2 - found=!found!
     )
 
     if "%found%" == "0" (
+        call :debug-output  :enhance_path - BEFORE Env Var - PATH=!path!
         if /i "%~2" == "append" (
             call :debug-output :enhance_path - Appending "%~1"
             set "PATH=%PATH%;%~1"
@@ -451,7 +440,7 @@ exit /b
             set "PATH=%~1;%PATH%"
         )
 
-        call :debug-output  :enhance_path - Env Var - PATH=!path!
+        call :debug-output  :enhance_path - AFTER Env Var - PATH=!path!
     )
 
     endlocal & set "PATH=%PATH%"

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -6,8 +6,65 @@
 :: !!! THIS FILE IS OVERWRITTEN WHEN CMDER IS UPDATED
 :: !!! Use "%CMDER_ROOT%\config\user-profile.cmd" to add your own startup commands
 
-:: Set to > 0 for verbose output to aid in debugging.
-if not defined verbose-output ( set verbose-output=0 )
+:: Use -v command line arg or set to > 0 for verbose output to aid in debugging.
+set verbose-output=0
+
+:var_loop
+    if "%~1" == "" (
+        goto :start
+    ) else if "%1"=="-v" (
+        set verbose-output=1
+    ) else if "%1" == "-a" (
+        if exist "%~2" (
+            set "user-aliases=%~2"
+            shift
+        ) else (
+            call :show_error The user aliases file, "%~2", you specified does not exist!
+            exit /b
+        )
+    ) else if "%1" == "-c" (
+        if not exist "%~2" (
+            echo WARNING: The CMDER user root folder "%~2", you specified does not exist!
+        )
+        if not exist "%~2\config\profile.d" md "%~2\config\profile.d"
+        if not exist "%~2\bin"  md "%~2\bin"
+        set "CMDER_USER_ROOT=%~2"
+        shift
+    ) else if "%1" == "-d" (
+        if exist "%~2" (
+          set "CMDER_START=%~2"
+          shift
+        ) else (
+          call :show_error The CMDER startup folder "%2", you specified does not exist!
+          exit /b
+        )
+    ) else if "%1" == "-g" (
+        if exist "%~2" (
+            set "GIT_INSTALL_ROOT=%~2"
+            shift
+        ) else (
+            call :show_error The Git install root folder "%2", you specified does not exist!
+            exit /b
+        )
+    ) else if "%1" == "-h" (
+        if exist "%~2" (
+            set "HOME=%~2"
+            shift
+        ) else (
+            call :show_error The home folder "%2", you specified does not exist!
+            exit /b
+        )
+    ) else if "%1" == "-s" (
+        set SVN_SSH=%2
+        shift
+    )
+    shift
+goto var_loop
+
+:start
+
+call :verbose-output verbose-output=%verbose-output%
+call :verbose-output CMDER_USER_ROOT=%CMDER_USER_ROOT%
 
 :: Find root dir
 if not defined CMDER_ROOT (
@@ -18,8 +75,9 @@ if not defined CMDER_ROOT (
     )
 )
 
-:: Remove trailing '\'
+:: Remove trailing '\' from %CMDER_ROOT%
 if "%CMDER_ROOT:~-1%" == "\" SET "CMDER_ROOT=%CMDER_ROOT:~0,-1%"
+call :verbose-output CMDER_ROOT=%CMDER_ROOT%
 
 :: Pick right version of clink
 if "%PROCESSOR_ARCHITECTURE%"=="x86" (
@@ -35,7 +93,11 @@ if not exist "%CMDER_ROOT%\config\settings" (
 )
 
 :: Run clink
-"%CMDER_ROOT%\vendor\clink\clink_x%architecture%.exe" inject --quiet --profile "%CMDER_ROOT%\config" --scripts "%CMDER_ROOT%\vendor"
+if defined CMDER_USER_ROOT (
+    "%CMDER_ROOT%\vendor\clink\clink_x%architecture%.exe" inject --quiet --profile "%CMDER_USER_ROOT%\config" --scripts "%CMDER_ROOT%\vendor"
+) else (
+    "%CMDER_ROOT%\vendor\clink\clink_x%architecture%.exe" inject --quiet --profile "%CMDER_ROOT%\config" --scripts "%CMDER_ROOT%\vendor"
+)
 
 :: Prepare for git-for-windows
 
@@ -119,22 +181,17 @@ if defined GIT_INSTALL_ROOT (
 
 :NO_GIT
 endlocal & set "PATH=%PATH%" & set "SVN_SSH=%SVN_SSH%" & set "GIT_INSTALL_ROOT=%GIT_INSTALL_ROOT%"
+call :verbose-output GIT_INSTALL_ROOT-output=%GIT_INSTALL_ROOT-output%
 
 :: Enhance Path
 set "PATH=%CMDER_ROOT%\bin;%PATH%;%CMDER_ROOT%\"
 
 :: Drop *.bat and *.cmd files into "%CMDER_ROOT%\config\profile.d"
 :: to run them at startup.
-if not exist "%CMDER_ROOT%\config\profile.d" (
-  mkdir "%CMDER_ROOT%\config\profile.d"
+call :run_profile_d "%CMDER_ROOT%\config\profile.d"
+if defined CMDER_USER_ROOT (
+  call :run_profile_d "%CMDER_USER_ROOT%\config\profile.d"
 )
-
-pushd "%CMDER_ROOT%\config\profile.d"
-for /f "usebackq" %%x in ( `dir /b *.bat *.cmd 2^>nul` ) do (
-  call :verbose-output Calling "%CMDER_ROOT%\config\profile.d\%%x"...
-  call "%CMDER_ROOT%\config\profile.d\%%x"
-)
-popd
 
 :: Allows user to override default aliases store using profile.d
 :: scripts run above by setting the 'aliases' env variable.
@@ -142,7 +199,13 @@ popd
 :: Note: If overriding default aliases store file the aliases
 :: must also be self executing, see '.\user-aliases.cmd.example',
 :: and be in profile.d folder.
-set "user-aliases=%CMDER_ROOT%\config\user-aliases.cmd"
+if not defined user-aliases (
+  if defined CMDER_USER_ROOT (
+     set "user-aliases=%CMDER_USER_ROOT%\config\user-aliases.cmd"
+  ) else (
+     set "user-aliases=%CMDER_ROOT%\config\user-aliases.cmd"
+  )
+)
 
 :: The aliases environment variable is used by alias.bat to id
 :: the default file to store new aliases in.
@@ -159,8 +222,13 @@ if not exist "%user-aliases%" (
     type "%user-aliases%" | findstr /i ";= Add aliases below here" >nul
     if "!errorlevel!" == "1" (
         echo Creating initial user-aliases store in "%user-aliases%"...
-        copy "%CMDER_ROOT%\%user-aliases%" "%user-aliases%.old_format"
-        copy "%CMDER_ROOT%\vendor\user-aliases.cmd.example" "%user-aliases%"
+        if defined CMDER_USER_ROOT (
+            copy "%user-aliases%" "%user-aliases%.old_format"
+            copy "%CMDER_ROOT%\vendor\user-aliases.cmd.example" "%user-aliases%"
+        ) else (
+            copy "%user-aliases%" "%user-aliases%.old_format"
+            copy "%CMDER_ROOT%\vendor\user-aliases.cmd.example" "%user-aliases%"
+        )
     )
 )
 
@@ -173,43 +241,57 @@ if exist "%CMDER_ROOT%\config\aliases" (
   type "%user-aliases%.old_format" >> "%user-aliases%" && del "%user-aliases%.old_format"
 )
 endlocal
+
 :: Add aliases to the environment
 call "%user-aliases%"
 
 :: See vendor\git-for-windows\README.portable for why we do this
 :: Basically we need to execute this post-install.bat because we are
 :: manually extracting the archive rather than executing the 7z sfx
-if exist "%CMDER_ROOT%\vendor\git-for-windows\post-install.bat" (
+if exist "%GIT_INSTALL_ROOT%\post-install.bat" (
     call :verbose-output Running Git for Windows one time Post Install....
-    pushd "%CMDER_ROOT%\vendor\git-for-windows\"
-    "%CMDER_ROOT%\vendor\git-for-windows\git-bash.exe" --no-needs-console --hide --no-cd --command=post-install.bat
+    pushd "%GIT_INSTALL_ROOT%\"
+    "%GIT_INSTALL_ROOT%\git-bash.exe" --no-needs-console --hide --no-cd --command=post-install.bat
     popd
 )
 
 :: Set home path
 if not defined HOME set "HOME=%USERPROFILE%"
+call :verbose-output HOME=%HOME%
 
-if exist "%CMDER_ROOT%\config\user-profile.cmd" (
+if exist "%CMDER_USER_ROOT%\config\user-profile.cmd" (
+    REM Create this file and place your own command in there
+    call "%CMDER_USER_ROOT%\config\user-profile.cmd"
+) else if exist "%CMDER_ROOT%\config\user-profile.cmd" (
     REM Create this file and place your own command in there
     call "%CMDER_ROOT%\config\user-profile.cmd"
 ) else (
     echo Creating user startup file: "%CMDER_ROOT%\config\user-profile.cmd"
     (
-    echo :: use this file to run your own startup commands
-    echo :: use  in front of the command to prevent printing the command
-    echo.
-    echo :: uncomment this to have the ssh agent load when cmder starts
-    echo :: call "%%GIT_INSTALL_ROOT%%/cmd/start-ssh-agent.cmd"
-    echo.
-    echo :: uncomment this next two lines to use pageant as the ssh authentication agent
-    echo :: SET SSH_AUTH_SOCK=/tmp/.ssh-pageant-auth-sock
-    echo :: call "%%GIT_INSTALL_ROOT%%/cmd/start-ssh-pageant.cmd"
-    echo.
-    echo :: you can add your plugins to the cmder path like so
-    echo :: set "PATH=%%CMDER_ROOT%%\vendor\whatever;%%PATH%%"
-    echo.
-    ) > "%CMDER_ROOT%\config\user-profile.cmd"
+echo :: use this file to run your own startup commands
+echo :: use  in front of the command to prevent printing the command
+echo.
+echo :: uncomment this to have the ssh agent load when cmder starts
+echo :: call "%%GIT_INSTALL_ROOT%%/cmd/start-ssh-agent.cmd"
+echo.
+echo :: uncomment this next two lines to use pageant as the ssh authentication agent
+echo :: SET SSH_AUTH_SOCK=/tmp/.ssh-pageant-auth-sock
+echo :: call "%%GIT_INSTALL_ROOT%%/cmd/start-ssh-pageant.cmd"
+echo.
+echo :: you can add your plugins to the cmder path like so
+echo :: set "PATH=%%CMDER_ROOT%%\vendor\whatever;%%PATH%%"
+echo.
+echo @echo off
+) >"%temp%\user-profile.tmp"
+
+  if defined CMDER_USER_ROOT (
+    copy "%temp%\user-profile.tmp" "%CMDER_USER_ROOT%\config\user-profile.cmd"
+  ) else (
+    copy "%temp%\user-profile.tmp" "%CMDER_ROOT%\config\user-profile.cmd"
+  )
 )
+
+if defined CMDER_START cd /d %CMDER_START%
 
 exit /b
 
@@ -307,3 +389,21 @@ goto :eof
     exit /b 0
 
 goto :eof
+
+:show_error
+    echo ERROR: %*
+    echo CMDER Shell Initialization has Failed!
+    exit /b
+
+:run_profile_d
+  if not exist "%~1" (
+    mkdir "%~1"
+  )
+  
+  pushd "%~1"
+  for /f "usebackq" %%x in ( `dir /b *.bat *.cmd 2^>nul` ) do (
+    call :verbose-output Calling "%~1\%%x"...
+    call "%~1\%%x"
+  )
+  popd
+  exit /b

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -55,10 +55,17 @@ if defined CMDER_USER_CONFIG (
 
 :: Find root dir
 if not defined CMDER_ROOT (
+    call :debug-output init.bat - CMDER_ROOT is not defined!
     if defined ConEmuDir (
-        for /f "delims=" %%i in ("%ConEmuDir%\..\..") do set "CMDER_ROOT=%%~fi"
+        for /f "delims=" %%i in ("%ConEmuDir%\..\..") do (
+            call :debug-output init.bat - Setting CMDER_ROOT based off of "%ConEmuDir%\..\.."
+            set "CMDER_ROOT=%%~fi"
+        )
     ) else (
-        for /f "delims=" %%i in ("%~dp0\..") do set "CMDER_ROOT=%%~fi"
+        for /f "delims=" %%i in ("%~dp0\..") do (
+            call :debug-output init.bat - Setting CMDER_ROOT based off of "%~dp0\.."
+            set "CMDER_ROOT=%%~fi"
+        )
     )
 )
 
@@ -172,7 +179,7 @@ call :debug-output init.bat - Env Var - GIT_INSTALL_ROOT=%GIT_INSTALL_ROOT%
 :: Enhance Path
 call :enhance_path "%CMDER_ROOT%\bin" 
 if defined CMDER_USER_BIN (
-  call :enhance_path "%CMDER_USER_BIN%\bin"
+  call :enhance_path "%CMDER_USER_BIN%"
 )
 call :enhance_path "%CMDER_ROOT%\" append
 
@@ -420,21 +427,21 @@ exit /b
         echo "%PATH%" | findstr /I /R ";%find_query%$" >nul
         if "!ERRORLEVEL!" == "0" set found=1
 
-        rem call :debug-output  :enhance_path - Env Var 1 - found=!found!
+        call :debug-output  :enhance_path - Env Var 1 - found=!found!
         if "!found!" == "0" (
             echo "%PATH%" | findstr /I /R ";%find_query%;" >nul
             if "!ERRORLEVEL!" == "0" set found=1
-            rem call :debug-output  :enhance_path - Env Var 2 - found=!found!
+            call :debug-output  :enhance_path - Env Var 2 - found=!found!
         )
     ) else (
-        echo "%PATH%"|findstr /I /R ";%~1;" >nul
+        echo "%PATH%"|findstr /I /R ";%find_query%" >nul
         if "!ERRORLEVEL!" == "0" set found=1
 
-        rem call :debug-output  :enhance_path - Env Var 1 - found=!found!
+        call :debug-output  :enhance_path - Env Var 1 - found=!found!
         if "!found!" == "0" (
-            echo "%PATH%" | findstr /I /R "^%find_query%;" >nul
+            echo "%PATH%" | findstr /I /R ";%find_query%;" >nul
             if "!ERRORLEVEL!" == "0" set found=1
-            rem call :debug-output  :enhance_path - Env Var 2 - found=!found!
+            call :debug-output  :enhance_path - Env Var 2 - found=!found!
         )
     )
 

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -39,8 +39,16 @@ if "%CMDER_ROOT:~-1%" == "\" SET "CMDER_ROOT=%CMDER_ROOT:~0,-1%"
             set "max_depth=%~2"
             shift
         ) else (
-            call :show_error '/enhance_path_recursive' requires a number between 1 and 5!
+            call :show_error '/max_depth' requires a number between 1 and 5!
             exit /b
+        )
+    ) else if "%1" == "/c" (
+        if exist "%~2" (
+            if not exist "%~2\bin" mkdir "%~2\bin"
+            set "cmder_user_bin=%~2\bin"
+            if not exist "%~2\config\profile.d" mkdir "%~2\config\profile.d"
+            set "cmder_user_config=%~2\config\profile.d"
+            shift
         )
     ) else if "%1" == "/user_aliases" (
         if exist "%~2" (

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -174,7 +174,7 @@ endlocal & set "PATH=%PATH%" & set "SVN_SSH=%SVN_SSH%" & set "GIT_INSTALL_ROOT=%
 call :debug-output init.bat - Env Var - GIT_INSTALL_ROOT=%GIT_INSTALL_ROOT%
 
 :: Enhance Path
-call :enhance_path "%CMDER_ROOT%\bin" 
+call :enhance_path_recursive "%CMDER_ROOT%\bin"
 if defined CMDER_USER_BIN (
   call :enhance_path "%CMDER_USER_BIN%"
 )
@@ -444,4 +444,15 @@ exit /b
     )
 
     endlocal & set "PATH=%PATH%"
+    exit /b
+
+:enhance_path_recursive
+    call :debug-output  :enhance_path_recursive - Adding parent directory - %1
+    call :enhance_path "%~1" %~2
+
+    for /d %%i in ("%~1%\*") do (
+        call :debug-output  :enhance_path_recursive - Found Subdirectory - %%~fi
+        call :enhance_path_recursive "%%~fi" %~2
+    )
+
     exit /b

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -18,9 +18,6 @@ set verbose-output=0
         if exist "%~2" (
             set "user-aliases=%~2"
             shift
-        ) else (
-            call :show_error The user aliases file, "%~2", you specified does not exist!
-            exit /b
         )
     ) else if "%1" == "/git_install_root" (
         if exist "%~2" (

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -239,7 +239,7 @@ call "%user-aliases%"
 :: Basically we need to execute this post-install.bat because we are
 :: manually extracting the archive rather than executing the 7z sfx
 if exist "%GIT_INSTALL_ROOT%\post-install.bat" (
-    call :verbose-output Running Git for Windows one time Post Install....
+    call :verbose-output init.bat - Running Git for Windows one time Post Install....
     pushd "%GIT_INSTALL_ROOT%\"
     "%GIT_INSTALL_ROOT%\git-bash.exe" --no-needs-console --hide --no-cd --command=post-install.bat
     popd
@@ -299,6 +299,19 @@ exit /b
       echo %*
     )
     exit /b
+
+:run_profile_d
+  if not exist "%~1" (
+    mkdir "%~1"
+  )
+  
+  pushd "%~1"
+  for /f "usebackq" %%x in ( `dir /b *.bat *.cmd 2^>nul` ) do (
+    call :verbose-output :run_profile_d - Calling "%~1\%%x"...
+    call "%~1\%%x"
+  )
+  popd
+  exit /b
 
 ::
 :: specific to git version comparing

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -47,7 +47,7 @@ if "%CMDER_ROOT:~-1%" == "\" SET "CMDER_ROOT=%CMDER_ROOT:~0,-1%"
             if not exist "%~2\bin" mkdir "%~2\bin"
             set "cmder_user_bin=%~2\bin"
             if not exist "%~2\config\profile.d" mkdir "%~2\config\profile.d"
-            set "cmder_user_config=%~2\config\profile.d"
+            set "cmder_user_config=%~2\config"
             shift
         )
     ) else if "%1" == "/user_aliases" (
@@ -131,7 +131,7 @@ setlocal enabledelayedexpansion
 call :read_version VENDORED "%CMDER_ROOT%\vendor\git-for-windows\cmd"
 
 :: check if git is in path...
-for /F "delims=" %%F in ('where git.exe 2^>nul') do @(
+for /F "delims=" %%F in ('where git.exe 2^>nul') do (
     :: get the absolute path to the user provided git binary
     pushd %%~dpF
     set "test_dir=!CD!"
@@ -353,7 +353,7 @@ exit /b
     )
 
     :: get the git version in the provided directory
-    for /F "tokens=1,2,3 usebackq" %%F in (`"%git_executable%" --version 2^>nul`) do @(
+    for /F "tokens=1,2,3 usebackq" %%F in (`"%git_executable%" --version 2^>nul`) do (
         if "%%F %%G" == "git version" (
             set "GIT_VERSION_%~1=%%H"
             call :debug-output :read_version - Env Var - GIT_VERSION_%~1=%%H

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -33,9 +33,9 @@ if "%CMDER_ROOT:~-1%" == "\" SET "CMDER_ROOT=%CMDER_ROOT:~0,-1%"
         set verbose-output=1
     ) else if "%1"=="/d" (
         set debug-output=1
-    ) else if "%1" == "/enhance_path_recursive" (
+    ) else if "%1" == "/max_depth" (
         if "%~2" geq "1" if "%~2" leq "5" (
-            set "enhance_path_recursive=%~2"
+            set "max_depth=%~2"
             shift
         ) else (
             call :show_error '/enhance_path_recursive' requires a number between 1 and 5!
@@ -182,9 +182,9 @@ endlocal & set "PATH=%PATH%" & set "SVN_SSH=%SVN_SSH%" & set "GIT_INSTALL_ROOT=%
 call :debug-output init.bat - Env Var - GIT_INSTALL_ROOT=%GIT_INSTALL_ROOT%
 
 :: Enhance Path
-call :enhance_path_recursive "%CMDER_ROOT%\bin" %enhance_path_recursive%
+call :enhance_path_recursive "%CMDER_ROOT%\bin" %max_depth%
 if defined CMDER_USER_BIN (
-  call :enhance_path "%CMDER_USER_BIN%" %enhance_path_recursive%
+  call :enhance_path "%CMDER_USER_BIN%" %max_depth%
 )
 call :enhance_path "%CMDER_ROOT%" append
 

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -10,6 +10,22 @@
 set verbose-output=0
 set debug-output=0
 
+:: Find root dir
+if not defined CMDER_ROOT (
+    if defined ConEmuDir (
+        for /f "delims=" %%i in ("%ConEmuDir%\..\..") do (
+            set "CMDER_ROOT=%%~fi"
+        )
+    ) else (
+        for /f "delims=" %%i in ("%~dp0\..") do (
+            set "CMDER_ROOT=%%~fi"
+        )
+    )
+)
+
+:: Remove trailing '\' from %CMDER_ROOT%
+if "%CMDER_ROOT:~-1%" == "\" SET "CMDER_ROOT=%CMDER_ROOT:~0,-1%"
+
 :var_loop
     if "%~1" == "" (
         goto :start
@@ -47,31 +63,12 @@ goto var_loop
 
 :start
 
+call :debug-output init.bat - Env Var - CMDER_ROOT=%CMDER_ROOT%
 call :debug-output init.bat - Env Var - debug-output=%debug-output%
 
 if defined CMDER_USER_CONFIG (
     call :debug-output init.bat - CMDER IS ALSO USING INDIVIDUAL USER CONFIG FROM '%CMDER_USER_CONFIG%'!
 )
-
-:: Find root dir
-if not defined CMDER_ROOT (
-    call :debug-output init.bat - CMDER_ROOT is not defined!
-    if defined ConEmuDir (
-        for /f "delims=" %%i in ("%ConEmuDir%\..\..") do (
-            call :debug-output init.bat - Setting CMDER_ROOT based off of "%ConEmuDir%\..\.."
-            set "CMDER_ROOT=%%~fi"
-        )
-    ) else (
-        for /f "delims=" %%i in ("%~dp0\..") do (
-            call :debug-output init.bat - Setting CMDER_ROOT based off of "%~dp0\.."
-            set "CMDER_ROOT=%%~fi"
-        )
-    )
-)
-
-:: Remove trailing '\' from %CMDER_ROOT%
-if "%CMDER_ROOT:~-1%" == "\" SET "CMDER_ROOT=%CMDER_ROOT:~0,-1%"
-call :debug-output init.bat - Env Var - CMDER_ROOT=%CMDER_ROOT%
 
 :: Pick right version of clink
 if "%PROCESSOR_ARCHITECTURE%"=="x86" (

--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -29,6 +29,10 @@ $ENV:CMDER_ROOT = (($ENV:CMDER_ROOT).trimend("\"))
 # -> recent PowerShell versions include PowerShellGet out of the box
 $moduleInstallerAvailable = [bool](Get-Command -Name 'Install-Module' -ErrorAction SilentlyContinue | Out-Null)
 
+# do not load bundled psget if a module installer is already available
+# -> recent PowerShell versions include PowerShellGet out of the box
+$moduleInstallerAvailable = [bool](Get-Command -Name 'Install-Module' -ErrorAction SilentlyContinue | Out-Null)
+
 # Add Cmder modules directory to the autoload path.
 $CmderModulePath = Join-path $PSScriptRoot "psmodules/"
 

--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -9,6 +9,10 @@ if(!$PSScriptRoot) {
     $PSScriptRoot = Split-Path $Script:MyInvocation.MyCommand.Path
 }
 
+if ($ENV:CMDER_USER_CONFIG) {
+    # write-host "CMDER IS ALSO USING INDIVIDUAL USER CONFIG FROM '$ENV:CMDER_USER_CONFIG'!"
+}
+
 # We do this for Powershell as Admin Sessions because CMDER_ROOT is not beng set.
 if (! $ENV:CMDER_ROOT ) {
     if ( $ENV:ConEmuDir ) {
@@ -130,9 +134,31 @@ foreach ($x in Get-ChildItem *.ps1) {
 }
 popd
 
+# Drop *.ps1 files into "$ENV:CMDER_USER_CONFIG\config\profile.d"
+# to source them at startup.  Requires using cmder.exe /C [cmder_user_root_path] argument
+if ($ENV:CMDER_USER_CONFIG -ne "" -and -not (test-path "$ENV:CMDER_USER_CONFIG\profile.d")) {
+    pushd $ENV:CMDER_USER_CONFIG\profile.d
+    foreach ($x in Get-ChildItem *.ps1) {
+      # write-host write-host Sourcing $x
+      . $x
+    }
+    popd
+}
+    
+
+
 $CmderUserProfilePath = Join-Path $env:CMDER_ROOT "config\user-profile.ps1"
-if(Test-Path $CmderUserProfilePath) {
+if (Test-Path $CmderUserProfilePath) {
     # Create this file and place your own command in there.
+    . "$CmderUserProfilePath"
+
+}
+
+if ($ENV:CMDER_USER_CONFIG) {
+    $CmderUserProfilePath = Join-Path $ENV:CMDER_USER_CONFIG "user-profile.ps1"
+}
+
+if (Test-Path $CmderUserProfilePath) {
     . "$CmderUserProfilePath"
 } else {
 # This multiline string cannot be indented, for this reason I've not indented the whole block


### PR DESCRIPTION
 ## [1.3.6-pre1](https://github.com/cmderdev/cmder) (2018-03-01)

The is a redo of #1665 - See the conversation there if you have questions.

**Fixed bugs:**

* Fixed Git version check recently added to master.

**Updates:**

* Modified Cmder tasks in default Conemu.xml to allow easily adding command line args for init.bat by adding some quotes.  This resulted in a ton of misc changes to this file.  See Adds below.
* Reworked `cmder.exe` command line argument handling to make it more flexible and easily added to.
* Reworked README.md tables to make them more readable in editors

**Implemented enhancements:**

* Append `%GIT_INSTALL_ROOT%\mingw32|64` folder to the path if it exists. Thanks: @gucong3000 
* Added `cmder.exe` command line args documenttion to `README.md`
* Added `:enhance_path` method to vendor\init.bat that modifies the path only if required.
   * To prepend: `call :enhance_path "%cmder_root%"`
   * to append: `call :enhance_path "%cmder_root%" append`
* Added `:enhance_path_recursive` method to vendor\init.bat that adds a path and all its sub directories to the path if required.  
   * Max recurse depth default is '1' configurable using `init.bat /max_depth [1-5]`. 6+ results in error. 
   * To prepend and go 3 levels deep: `call :enhance_path "%cmder_root%" 3`
   * To append and go 2 levels deep: `call :enhance_path "%cmder_root%" 2 append`
* Added ability to init.bat to accept command line args and documented them in README.md.  Allows users to change the behaviour of init.bat without editing the file.

| Argument                      | Description                                                                                      | Default                               |
| ----------------------------- | ----------------------------------------------------------------------------------------------   | ------------------------------------- |
| /c [user cmder root]          | Enables user bin and config folders for 'Cmder as admin' sessions due to non-shared environment. | not set                               |
| /d                            | Enables debug output.                                                                            | not set                               |
| /git_install_root [file path] | User specified Git installation root path.                                                       | '%CMDER_ROOT%\vendor\Git-for-Windows' |
| /home [home folder]           | User specified folder path to set `%HOME%` environment variable.                                 | '%userprofile%'                       |
| /max_depth [1-5]              | Define max recurse depth when adding to the path for `%cmder_root%\bin` and `%cmder_user_bin%`   | 1                                     |
| /svn_ssh [path to ssh.exe]    | Define %SVN_SSH% so we can use git svn with ssh svn repositories.                                | '%GIT_INSTALL_ROOT%\bin\ssh.exe'      |
| /user_aliases [file path]     | File path pointing to user aliases.                                                              | '%CMDER_ROOT%\config\user-liases.cmd' |
| /v                            | Enables verbose output.                                                                          | not set                               |

* Added new `cmder.exe /C \<path\>` argument
   * To use run Cmder.exe with "/C" command line argument. Example: `cmder.exe /C %userprofile%\cmder_config`
   * To use run with `Cmder as Admin` sessions you must specify "/c" command line argument to `init.bat` in tasks. See [README.md](./Readme.md) for details.
   * Enables shared Cmder install with Non-Portable Individual User Config
   * Supported by all supported shells (cmder, powershell, git bash, and external bash)
   * This will create the following directory structure if it is missing.

      ```
      c:\users\[username]\cmder_config
      ├───bin
      └───config
          └───profile.d
      ```

   * Shell init scripts run in the following order
      1. %cmder_root%\config\profile.d\*.[cmd|ps1|sh]
      1. %cmder_root%\config\user-profile.[cmd|ps1|sh]
      1. %userprofile%\cmder_config\config\profile.d\*.[cmd|ps1|sh]
      1. %userprofile%\cmder_config\config\user-profile.[cmd|ps1|sh]