### PR TITLE
Adding a `issue_template.md` for Cmder

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,67 @@
+<!--
+
+  Thank you for reporting a bug for the Cmder project!
+  ------------------------------------------------------------------
+  
+  Please make sure you read and follow the following instructions
+  before reporting bugs, and/or requesting new features.
+  
+  Make sure that you have:
+  
+  • Searched for existing issues (including the **closed** ones)
+    for the similar problems here:
+    https://github.com/cmderdev/cmder/issues?q=is:issue
+    
+  • Read the README.md and the Wiki:
+    - https://github.com/cmderdev/cmder/blob/master/README.md
+    - https://github.com/cmderdev/cmder/wiki
+    
+    (What you may be asking here could already be explained there!)
+    
+  • Please understand that Cmder by default uses ConEmu as the
+    underlying Terminal Emulator. If your issue is regarding
+    the **Terminal Emulator**, please visit the ConEmu issues page:
+    
+    https://github.com/Maximus5/ConEmu/issues?q=is:issue
+    
+    If there isn't an existing issue, you may open a new one.
+    
+    (We don't resolve issues regarding ConEmu here, so please 
+     make sure you open the issue in the correct place.)
+     
+  • If you are asking for Guides on how to integrate Cmder into
+    your favorite IDE of choice, or how to perform an specific
+    task with Cmder, make sure you visit our Guides section first:
+    
+    - https://github.com/cmderdev/cmder/issues?q=label:Guide
+    - https://github.com/cmderdev/cmder/issues?q=label:Question
+     
+  • If the issue is regarding the other upstream technologies that
+    Cmder uses (e.g. Clink, Git, etc), please make sure that the
+    bug you are reporting only applies when they are used in
+    combination with Cmder. If the bug applies when the mentioned
+    tools are NOT used within Cmder, there's a good chance that
+    you should open the bug at the corresponding repo instead.
+    
+    
+  Thank you for making sure you are opening a new valid issue!
+  
+-->
+
+<!-- 
+  Some tips on how to write a better report:
+  - Put an `x` into all the boxes [ ] relevant to your issue (example: [x]).
+  - Use the *Preview* tab to see how your issue will actually look like, before sending it.
+  - Make sure the description is worded well enough to be understood, and with as much context and examples as possible.
+  - Post a screenshot or the command the triggered the problem, if applicable.
+  - Avoid using ambiguous phrases like: doesn't work, there'a problem, etc.
+    Help us reproduce the issue by explaining what went wrong, and what did you expect to happen.
+-->
+
+### Purpose of the issue
+- [ ] Bug report (encountered problems/errors)
+- [ ] Feature request (request for new functionality)
+- [ ] Question
+
+### Description of the issue 
+


### PR DESCRIPTION

## Issue Template
It seems that there are a lot of unnecessary issues made in Cmder's repo by users, most of which are related to the ConEmu and some are invalid.

I propose adding an [**Issue Template**](https://help.github.com/articles/creating-an-issue-template-for-your-repository/) to the Cmder, which helps users make sure they are a) creating a valid issue and b) in the right place.

This would:
- Prevent duplicated/similar issues
- Explain the suitable repo for each issue, avoiding ConEmu issues here.
- Help users to provide a better explanation to identify the problem