### PR TITLE
open cmder in the current working dir as every other windows app works

### DIFF
--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -208,15 +208,6 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 		PathCombine(conEmuPath, exeDir, L"vendor\\conemu-maximus5\\ConEmu.exe");
 	}
 
-  /*
-	if (streqi(cmderStart.c_str(), L""))
-	{
-		TCHAR buff[MAX_PATH];
-		const DWORD ret = GetEnvironmentVariable(L"USERPROFILE", buff, MAX_PATH);
-		cmderStart = buff;
-	}
-  */
-
 	if (is_single_mode)
 	{
 		if (!streqi(cmderTask.c_str(), L"")) {

--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -208,12 +208,14 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 		PathCombine(conEmuPath, exeDir, L"vendor\\conemu-maximus5\\ConEmu.exe");
 	}
 
+  /*
 	if (streqi(cmderStart.c_str(), L""))
 	{
 		TCHAR buff[MAX_PATH];
 		const DWORD ret = GetEnvironmentVariable(L"USERPROFILE", buff, MAX_PATH);
 		cmderStart = buff;
 	}
+  */
 
 	if (is_single_mode)
 	{


### PR DESCRIPTION
Opens cmder in the current working directory unless `[path]` or `/start [path]` arg is used.