### PR TITLE
Fixes

### DIFF
--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -334,7 +334,7 @@ void UnregisterShellMenu(std::wstring opt, wchar_t* keyBaseName)
 	HKEY cmderKey;
 	FAIL_ON_ERROR(RegCreateKeyEx(root, keyBaseName, 0, NULL, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL, &cmderKey, NULL));
 	FAIL_ON_ERROR(RegDeleteTree(cmderKey, NULL));
-  RegDeleteKeyEx(root, keyBaseName, KEY_ALL_ACCESS, NULL);
+	RegDeleteKeyEx(root, keyBaseName, KEY_ALL_ACCESS, NULL);
 	RegCloseKey(cmderKey);
 	RegCloseKey(root);
 }

--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -334,6 +334,7 @@ void UnregisterShellMenu(std::wstring opt, wchar_t* keyBaseName)
 	HKEY cmderKey;
 	FAIL_ON_ERROR(RegCreateKeyEx(root, keyBaseName, 0, NULL, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL, &cmderKey, NULL));
 	FAIL_ON_ERROR(RegDeleteTree(cmderKey, NULL));
+  RegDeleteKeyEx(root, keyBaseName, KEY_ALL_ACCESS, NULL);
 	RegCloseKey(cmderKey);
 	RegCloseKey(root);
 }

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -302,8 +302,8 @@ if defined CMDER_USER_CONFIG (
 )
 
 if not exist "%initialConfig%" (
-    (
     echo Creating user startup file: "%initialConfig%"
+    (
 echo :: use this file to run your own startup commands
 echo :: use  in front of the command to prevent printing the command
 echo.

--- a/vendor/lib/lib_console.cmd
+++ b/vendor/lib/lib_console.cmd
@@ -76,5 +76,4 @@ exit /b
 :::-------------------------------------------------------------------------------
 
     echo ERROR: %~1
-    echo CMDER Shell Initialization has Failed!
     exit /b

--- a/vendor/lib/lib_git.cmd
+++ b/vendor/lib/lib_git.cmd
@@ -45,17 +45,20 @@ exit /b
     %lib_console% debug-output :read_version "Env Var - git_executable=%git_executable%"
 
     :: check if the executable actually exists
-    if exist "%git_executable%" (
-        :: get the git version in the provided directory
-        for /F "tokens=1,2,3 usebackq" %%A in (`"%git_executable%" --version 2^>nul`) do (
-            if /i "%%A %%B" == "git version" (
-                set "GIT_VERSION_%~1=%%C"
-                %lib_console% debug-output :read_version "Env Var - GIT_VERSION_%~1=%%C"
-            ) else (
-                %lib_console% show_error "git --version" returned an inproper version string!
-                pause
-                exit /b
-            )
+    if not exist "%git_executable%" (
+        %lib_console% debug-output :reda_version "%git_executable% does not exist."
+        exit /b -255
+    )
+
+    :: get the git version in the provided directory
+    for /F "tokens=1,2,3 usebackq" %%A in (`"%git_executable%" --version 2^>nul`) do (
+        if /i "%%A %%B" == "git version" (
+            set "GIT_VERSION_%~1=%%C"
+            %lib_console% debug-output :read_version "Env Var - GIT_VERSION_%~1=%%C"
+        ) else (
+            %lib_console% show_error "git --version" returned an inproper version string!
+            pause
+            exit /b
         )
     )
 

--- a/vendor/lib/lib_git.cmd
+++ b/vendor/lib/lib_git.cmd
@@ -46,7 +46,7 @@ exit /b
 
     :: check if the executable actually exists
     if not exist "%git_executable%" (
-        %lib_console% debug-output :reda_version "%git_executable% does not exist."
+        %lib_console% debug-output :read_version "%git_executable% does not exist."
         exit /b -255
     )
 

--- a/vendor/lib/lib_git.cmd
+++ b/vendor/lib/lib_git.cmd
@@ -45,20 +45,17 @@ exit /b
     %lib_console% debug-output :read_version "Env Var - git_executable=%git_executable%"
 
     :: check if the executable actually exists
-    if not exist "%git_executable%" (
-        %lib_console% show_error "%git_executable%" does not exist!
-        exit /b -255
-    )
-
-    :: get the git version in the provided directory
-    for /F "tokens=1,2,3 usebackq" %%A in (`"%git_executable%" --version 2^>nul`) do (
-        if /i "%%A %%B" == "git version" (
-            set "GIT_VERSION_%~1=%%C"
-            %lib_console% debug-output :read_version "Env Var - GIT_VERSION_%~1=%%C"
-        ) else (
-            %lib_console% show_error "git --version" returned an inproper version string!
-            pause
-            exit /b
+    if exist "%git_executable%" (
+        :: get the git version in the provided directory
+        for /F "tokens=1,2,3 usebackq" %%A in (`"%git_executable%" --version 2^>nul`) do (
+            if /i "%%A %%B" == "git version" (
+                set "GIT_VERSION_%~1=%%C"
+                %lib_console% debug-output :read_version "Env Var - GIT_VERSION_%~1=%%C"
+            ) else (
+                %lib_console% show_error "git --version" returned an inproper version string!
+                pause
+                exit /b
+            )
         )
     )
 


### PR DESCRIPTION
### Fixes

* /unregister now cleans up after itself.
* don't show git not found on cmder mini cmder shells when looking for vendored git. #1497, #1726
* don't add extra error message on show_error