### PR TITLE
Fix GIthub Github Download failures

### DIFF
--- a/scripts/utils.ps1
+++ b/scripts/utils.ps1
@@ -200,6 +200,8 @@ function Download-File {
         $Url,
         $File
     )
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    
     # I think this is the problem
     $File = $File -Replace "/", "\"
     Write-Verbose "Downloading from $Url to $File"


### PR DESCRIPTION
* Github changed to only accept TLS 1.2 connections, this fixes the resulting failures.