### PR TITLE
Set cmderStart to launcher's current working directory as fallback

### DIFF
--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -433,7 +433,25 @@ cmderOptions GetOption()
 			cmderOptions.error = true;
 		}
 	}
-
+	
+	if (cmderOptions.cmderStart == L"") 
+	{
+		TCHAR currentWorkingDir[MAX_PATH];
+		if (GetCurrentDirectory(MAX_PATH, currentWorkingDir) == 0)
+		{
+			MessageBox(NULL, L"Failed querying current directory", MB_TITLE, MB_OK);
+			cmderOptions.error = true;
+		}
+		else if (PathFileExists(currentWorkingDir)) 
+		{
+			cmderOptions.cmderStart = currentWorkingDir;
+		}
+		else 
+		{
+			MessageBox(NULL, currentWorkingDir, L"Current working diectory doses not exist!", MB_OK);
+		}
+	}
+	
 	LocalFree(szArgList);
 
 	return cmderOptions;


### PR DESCRIPTION
When you open the launcher from the address bar windows sets the path as its working directory(instead of passing it as an argument). The launcher doesn't pass that option to ConEmu, which ends up using `%USERPROFILE%`:

![image](https://user-images.githubusercontent.com/24456233/39872548-02d6b85a-5471-11e8-8c80-6a2d3969606c.png)

This is a more elegant fix for the workaround mention in #1414, which stopped working because `%ConEmuWorkDir%` isn't set in the host process.
