### PR TITLE
Fix lib base

### DIFF
--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -129,12 +129,14 @@ if not defined TERM set TERM=cygwin
 :: * test if a git is in path and if yes, use that
 :: * last, use our vendored git
 :: also check that we have a recent enough version of git by examining the version string
+setlocal enabledelayedexpansion
 if defined GIT_INSTALL_ROOT (
     if exist "%GIT_INSTALL_ROOT%\cmd\git.exe" goto :FOUND_GIT)
 )
 
+%lib_console% debug-output init.bat "Looking for Git install root..."
+
 :: get the version information for vendored git binary
-setlocal enabledelayedexpansion
 %lib_git% read_version VENDORED "%CMDER_ROOT%\vendor\git-for-windows\cmd"
 %lib_git% validate_version VENDORED !GIT_VERSION_VENDORED!
 
@@ -203,11 +205,16 @@ if defined GIT_INSTALL_ROOT (
     if not defined SVN_SSH set "SVN_SSH=%GIT_INSTALL_ROOT:\=\\%\\bin\\ssh.exe"
 )
 
-:NO_GIT
-endlocal & set "PATH=%PATH%" & set "SVN_SSH=%SVN_SSH%" & set "GIT_INSTALL_ROOT=!GIT_INSTALL_ROOT!"
-%lib_console% debug-output init.bat "Env Var - GIT_INSTALL_ROOT=!GIT_INSTALL_ROOT!"
+endlocal & set "PATH=%PATH%" & set "SVN_SSH=%SVN_SSH%" & set "GIT_INSTALL_ROOT=%GIT_INSTALL_ROOT%"
+%lib_console% debug-output init.bat "Env Var - GIT_INSTALL_ROOT=%GIT_INSTALL_ROOT%"
+%lib_console% debug-output init.bat "Found Git in: '%GIT_INSTALL_ROOT%'"
+goto :PATH_ENHANCE
 
-:: Enhance Path
+:NO_GIT
+:: Skip this if GIT WAS FOUND else we did 'endlocal' above!
+endlocal
+
+:PATH_ENHANCE
 %lib_path% enhance_path_recursive "%CMDER_ROOT%\bin" %max_depth%
 if defined CMDER_USER_BIN (
   %lib_path% enhance_path_recursive "%CMDER_USER_BIN%" %max_depth%

--- a/vendor/lib/lib_base.cmd
+++ b/vendor/lib/lib_base.cmd
@@ -3,7 +3,7 @@
 set lib_base=call "%~dp0lib_base.cmd"
 
 if "%~1" == "/h" (
-    %lib_base% help "%0"
+    %lib_base% help "%~0"
 ) else if "%1" neq "" (
     call :%*
 )

--- a/vendor/lib/lib_base.cmd
+++ b/vendor/lib/lib_base.cmd
@@ -16,7 +16,7 @@ exit /b
 :::.
 :::include:
 :::.
-:::       call "$0"
+:::       call "lib_base.cmd"
 :::.
 :::usage:
 :::.
@@ -27,12 +27,9 @@ exit /b
 :::       file <in> full path to file containing lib_routines to display
 :::.
 :::-------------------------------------------------------------------------------
-
     for /f "tokens=* delims=:" %%a in ('type "%~1" ^| findstr /i /r "^:::"') do (
         rem echo a="%%a"
 
-        if "%%a"==" " (
-            echo.
         if "%%a"=="." (
             echo.
         ) else if /i "%%a" == "usage" (

--- a/vendor/lib/lib_console.cmd
+++ b/vendor/lib/lib_console.cmd
@@ -19,7 +19,7 @@ exit /b
 :::.
 :::include:
 :::.
-:::  call "$0"
+:::  call "lib_console.cmd"
 :::.
 :::usage:
 :::.

--- a/vendor/lib/lib_console.cmd
+++ b/vendor/lib/lib_console.cmd
@@ -6,7 +6,7 @@ call "%~dp0lib_base.cmd"
 set lib_console=call "%~dp0lib_console.cmd"
 
 if "%~1" == "/h" (
-    %lib_base% help "%0"
+    %lib_base% help "%~0"
 ) else if "%1" neq "" (
     call :%*
 )

--- a/vendor/lib/lib_git.cmd
+++ b/vendor/lib/lib_git.cmd
@@ -7,6 +7,7 @@ set lib_git=call "%~dp0lib_git.cmd"
 
 
 if "%~1" == "/h" (
+    echo %lib_base% help "%~0"
     %lib_base% help "%~0"
 ) else if "%1" neq "" (
     call :%*
@@ -20,7 +21,7 @@ exit /b
 :::.
 :::include:
 :::.
-:::  call "$0"
+:::  call "lib_git.cmd"
 :::.
 :::usage:
 :::.

--- a/vendor/lib/lib_git.cmd
+++ b/vendor/lib/lib_git.cmd
@@ -7,7 +7,7 @@ set lib_git=call "%~dp0lib_git.cmd"
 
 
 if "%~1" == "/h" (
-    %lib_base% help "%0"
+    %lib_base% help "%~0"
 ) else if "%1" neq "" (
     call :%*
 )

--- a/vendor/lib/lib_git.cmd
+++ b/vendor/lib/lib_git.cmd
@@ -7,7 +7,6 @@ set lib_git=call "%~dp0lib_git.cmd"
 
 
 if "%~1" == "/h" (
-    echo %lib_base% help "%~0"
     %lib_base% help "%~0"
 ) else if "%1" neq "" (
     call :%*

--- a/vendor/lib/lib_path.cmd
+++ b/vendor/lib/lib_path.cmd
@@ -19,7 +19,7 @@ exit /b
 :::
 :::include:
 :::
-:::  call "$0"
+:::  call "lib_path.cmd"
 :::
 :::usage:
 :::

--- a/vendor/lib/lib_path.cmd
+++ b/vendor/lib/lib_path.cmd
@@ -6,7 +6,7 @@ call "%%~dp0lib_console"
 set lib_path=call "%~dp0lib_path.cmd"
 
 if "%~1" == "/h" (
-    %lib_base% help "%0"
+    %lib_base% help "%~0"
 ) else if "%1" neq "" (
     call :%*
 )

--- a/vendor/lib/lib_profile.cmd
+++ b/vendor/lib/lib_profile.cmd
@@ -19,7 +19,7 @@ exit /b
 :::
 :::include:
 :::
-:::  call "$0"
+:::  call "lib_profile.cmd"
 :::
 :::usage:
 :::

--- a/vendor/lib/lib_profile.cmd
+++ b/vendor/lib/lib_profile.cmd
@@ -6,7 +6,7 @@ call "%%~dp0lib_console"
 set lib_profile=call "%~dp0lib_profile.cmd"
 
 if "%~1" == "/h" (
-    %lib_base% help "%0"
+    %lib_base% help "%~0"
 ) else if "%1" neq "" (
     call :%*
 )


### PR DESCRIPTION
Fixes command line help for libs.  Access it by typing `./vendor/libs/lib_path.cmd /h`
Fixes #1791 