### PR TITLE
Dot-Sourcing Error: PowerShell 5.1 and Windows Software Restriction Policy compatibility

### DIFF
--- a/config/ConEmu.xml
+++ b/config/ConEmu.xml
@@ -508,7 +508,7 @@
 					<value name="Name" type="string" data="{PowerShell::PowerShell as Admin}"/>
 					<value name="Hotkey" type="dword" data="00000000"/>
 					<value name="GuiArgs" type="string" data=" /icon &quot;%CMDER_ROOT%\icons\cmder.ico&quot;"/>
-					<value name="Cmd1" type="string" data="*PowerShell -ExecutionPolicy Bypass -NoLogo -NoProfile -NoExit -Command &quot;Invoke-Expression '. ''%ConEmuDir%\..\profile.ps1'''&quot;"/>
+					<value name="Cmd1" type="string" data="*PowerShell -ExecutionPolicy Bypass -NoLogo -NoProfile -NoExit -Command &quot;Invoke-Expression 'Import-Module ''%ConEmuDir%\..\profile.ps1'''&quot;"/>
 					<value name="Active" type="long" data="0"/>
 					<value name="Count" type="long" data="1"/>
 					<value name="Flags" type="dword" data="00000000"/>
@@ -517,7 +517,7 @@
 					<value name="Name" type="string" data="{PowerShell::PowerShell}"/>
 					<value name="Hotkey" type="dword" data="00000000"/>
 					<value name="GuiArgs" type="string" data=" /icon &quot;%CMDER_ROOT%\icons\cmder.ico&quot;"/>
-					<value name="Cmd1" type="string" data="PowerShell -ExecutionPolicy Bypass -NoLogo -NoProfile -NoExit -Command &quot;Invoke-Expression '. ''%ConEmuDir%\..\profile.ps1'''&quot;"/>
+					<value name="Cmd1" type="string" data="PowerShell -ExecutionPolicy Bypass -NoLogo -NoProfile -NoExit -Command &quot;Invoke-Expression 'Import-Module ''%ConEmuDir%\..\profile.ps1'''&quot;"/>
 					<value name="Cmd2" type="string" data="&quot;%CMDER_ROOT%\vendor\git-for-windows\git-bash.exe&quot;"/>
 					<value name="Active" type="long" data="0"/>
 					<value name="Count" type="long" data="1"/>

--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -134,7 +134,7 @@ if (-not (test-path "$ENV:CMDER_ROOT\config\profile.d")) {
 pushd $ENV:CMDER_ROOT\config\profile.d
 foreach ($x in Get-ChildItem *.ps1) {
   # write-host write-host Sourcing $x
-  . $x
+  Import-Module $x
 }
 popd
 
@@ -144,7 +144,7 @@ if ($ENV:CMDER_USER_CONFIG -ne "" -and (test-path "$ENV:CMDER_USER_CONFIG\profil
     pushd $ENV:CMDER_USER_CONFIG\profile.d
     foreach ($x in Get-ChildItem *.ps1) {
       # write-host write-host Sourcing $x
-      . $x
+      Import-Module $x
     }
     popd
 }
@@ -154,13 +154,13 @@ if ($ENV:CMDER_USER_CONFIG -ne "" -and (test-path "$ENV:CMDER_USER_CONFIG\profil
 $CmderUserProfilePath = Join-Path $env:CMDER_ROOT "config\user-profile.ps1"
 if (Test-Path $CmderUserProfilePath) {
     # Create this file and place your own command in there.
-    . "$CmderUserProfilePath"
+    Import-Module "$CmderUserProfilePath"
 }
 
 if ($ENV:CMDER_USER_CONFIG) {
     $CmderUserProfilePath = Join-Path $ENV:CMDER_USER_CONFIG "user-profile.ps1"
     if (Test-Path $CmderUserProfilePath) {
-      . "$CmderUserProfilePath"
+      Import-Module "$CmderUserProfilePath"
     }
 }
 


### PR DESCRIPTION
Went into trouble when tried to start powershell tab after updating PS to version 5.1.

bin\vendor\profile.ps1 : Cannot dot-source this command because it was defined in a different language mode. To invoke this command without importing its contents, omit the '.'  operator.
At line:1 char:1
+ . 'bin\vendor\conemu-maximus5\..\profi ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [profile.ps1], NotSupportedException
    + FullyQualifiedErrorId : DotSourceNotSupported,profile.ps1

Google helped me to find out that "." invocation (dot-sourcing) is kinda deprecated or announced as insecure feature, but can be replaced with Import-Module commandlet