### PR TITLE
Initialize time_init to fix init error message

### DIFF
--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -11,6 +11,7 @@ set cmder_init_start=%time%
 :: Use /v command line arg or set to > 0 for verbose output to aid in debugging.
 set verbose_output=0
 set debug_output=0
+set time_init=0
 set max_depth=1
 set "CMDER_USER_FLAGS= "
 


### PR DESCRIPTION
Fix to #1918: Make sure %time_init% is initialized, otherwise this line causes an error each time a cmd shell is created:

    if %time_init% gtr 0