### PR TITLE
Use user_conemu.xml or conemu-%computername%.xml directly if '-c [path]' is used to start cmder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ vendor/*/*
 config/*
 !config/Readme.md
 
+config_user/*
+
 Thumbs.db
 *.exe
 *.dll

--- a/README.md
+++ b/README.md
@@ -41,12 +41,15 @@ The Cmder's user interface is also designed to be more eye pleasing, and you can
 ## Cmder.exe Command Line Arguments
 
 
-| Argument            | Description                                                                 |
-| ------------------- | -----------------------------------------------------------------------     |
-| `/C [user_root_path]` | Individual user Cmder root folder.  Example: `%userprofile%\cmder_config` |
-| `/SINGLE`             | Start Cmder in single mode.                                               |
-| `/START [start_path]` | Folder path to start in.                                                  |
-| `/TASK [task_name]`   | Task to start after launch.                                               |
+| Argument                  | Description                                                                              |
+| -------------------       | -----------------------------------------------------------------------                  |
+| `/C [user_root_path]`     | Individual user Cmder root folder.  Example: `%userprofile%\cmder_config`                |
+| `/M`                      | Use `conemu-%computername%.xml` for ConEmu settings storage instead of `user_conemu.xml` |
+| `/REGISTER [ALL, USER]`   | Register a Windows Shell Menu shortcut.                                                  |
+| `/UNREGISTER [ALL, USER]` | Un-register a Windows Shell Menu shortcut.                                               |
+| `/SINGLE`                 | Start Cmder in single mode.                                                              |
+| `/START [start_path]`     | Folder path to start in.                                                                 |
+| `/TASK [task_name]`       | Task to start after launch.                                                              |
 
 ## Context Menu Integration
 

--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -442,8 +442,10 @@ HKEY GetRootKey(std::wstring opt)
 	return root;
 }
 
-void RegisterShellMenu(std::wstring opt, wchar_t* keyBaseName)
+void RegisterShellMenu(std::wstring opt, wchar_t* keyBaseName, std::wstring cfgRoot = L"")
 {
+	wchar_t userConfigDirPath[MAX_PATH] = { 0 };
+
 	// First, get the paths we will use
 
 	wchar_t exePath[MAX_PATH] = { 0 };
@@ -452,7 +454,16 @@ void RegisterShellMenu(std::wstring opt, wchar_t* keyBaseName)
 	GetModuleFileName(NULL, exePath, sizeof(exePath));
 
 	wchar_t commandStr[MAX_PATH + 20] = { 0 };
-	swprintf_s(commandStr, L"\"%s\" \"%%V\"", exePath);
+
+	if (cfgRoot.length() == 0) // '/c [path]' was NOT specified
+	{
+		swprintf_s(commandStr, L"\"%s\" \"%%V\"", exePath);
+	}
+	else {
+		std::copy(cfgRoot.begin(), cfgRoot.end(), userConfigDirPath);
+		userConfigDirPath[cfgRoot.length()] = 0;
+		swprintf_s(commandStr, L"\"%s\" /c \"%s\" \"%%V\"", exePath, userConfigDirPath);
+	}
 
 	// Now that we have `commandStr`, it's OK to change `exePath`...
 	PathRemoveFileSpec(exePath);
@@ -635,8 +646,8 @@ int APIENTRY _tWinMain(_In_ HINSTANCE hInstance,
 
 	if (cmderOptions.registerApp == true)
 	{
-		RegisterShellMenu(cmderOptions.cmderRegScope, SHELL_MENU_REGISTRY_PATH_BACKGROUND);
-		RegisterShellMenu(cmderOptions.cmderRegScope, SHELL_MENU_REGISTRY_PATH_LISTITEM);
+		RegisterShellMenu(cmderOptions.cmderRegScope, SHELL_MENU_REGISTRY_PATH_BACKGROUND, cmderOptions.cmderCfgRoot);
+		RegisterShellMenu(cmderOptions.cmderRegScope, SHELL_MENU_REGISTRY_PATH_LISTITEM, cmderOptions.cmderCfgRoot);
 	}
 	else if (cmderOptions.unRegisterApp == true)
 	{

--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -69,7 +69,7 @@ bool FileExists(const wchar_t * filePath)
 	return false;
 }
 
-void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstring taskName = L"", std::wstring cfgRoot = L"")
+void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstring taskName = L"", std::wstring cfgRoot = L"", bool use_user_cfg = true)
 {
 #if USE_TASKBAR_API
 	wchar_t appId[MAX_PATH] = { 0 };
@@ -218,7 +218,7 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 	// Set path to Cmder user ConEmu config file
 	PathCombine(userCfgPath, userConfigDirPath, L"user-ConEmu.xml");
 
-	if (PathFileExists(cpuCfgPath)) // config/ConEmu-%COMPUTERNAME%.xml file exists, use it.
+	if ( PathFileExists(cpuCfgPath) || use_user_cfg == false ) // config/ConEmu-%COMPUTERNAME%.xml file exists or /m was specified on command line, use machine specific config.
 	{
 		if (cfgRoot.length() == 0) // '/c [path]' was NOT specified
 		{
@@ -486,6 +486,7 @@ struct cmderOptions
 	std::wstring cmderTask = L"";
 	std::wstring cmderRegScope = L"USER";
 	bool cmderSingle = false;
+	bool cmderUserCfg = true;
 	bool registerApp = false;
 	bool unRegisterApp = false;
 	bool error = false;
@@ -546,6 +547,10 @@ cmderOptions GetOption()
 		{
 			cmderOptions.cmderSingle = true;
 		}
+		else if (_wcsicmp(L"/m", szArgList[i]) == 0)
+		{
+			cmderOptions.cmderUserCfg = false;
+		}
 		else if (_wcsicmp(L"/register", szArgList[i]) == 0)
 		{
 			cmderOptions.registerApp = true;
@@ -592,7 +597,7 @@ cmderOptions GetOption()
 		}
 		else 
 		{
-			MessageBox(NULL, L"Unrecognized parameter.\n\nValid options:\n\n    /c [CMDER User Root Path]\n\n    /task [ConEmu Task Name]\n\n    [/start [Start in Path] | [Start in Path]]\n\n    /single\n\nor\n\n    /register [USER | ALL]\n\nor\n\n    /unregister [USER | ALL]\n", MB_TITLE, MB_OK);
+			MessageBox(NULL, L"Unrecognized parameter.\n\nValid options:\n\n    /c [CMDER User Root Path]\n\n    /task [ConEmu Task Name]\n\n    [/start [Start in Path] | [Start in Path]]\n\n    /single\n\n    /m\n\nor\n\n    /register [USER | ALL]\n\nor\n\n    /unregister [USER | ALL]\n", MB_TITLE, MB_OK);
 			cmderOptions.error = true;
 		}
 	}
@@ -629,7 +634,7 @@ int APIENTRY _tWinMain(_In_ HINSTANCE hInstance,
 	}
 	else
 	{
-		StartCmder(cmderOptions.cmderStart, cmderOptions.cmderSingle, cmderOptions.cmderTask, cmderOptions.cmderCfgRoot);
+		StartCmder(cmderOptions.cmderStart, cmderOptions.cmderSingle, cmderOptions.cmderTask, cmderOptions.cmderCfgRoot, cmderOptions.cmderUserCfg);
 	}
 
 	return 0;

--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -295,7 +295,7 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 					: L"Failed to copy vendor/conemu-maximus5/ConEmu.xml file to config/user-conemu.xml!", MB_TITLE, MB_ICONSTOP);
 				exit(1);
 			}
-			else // vendor/ConEmu.xml config exists, copy Cmder vendor/ConEmu.xml.default file to vendor/conemu-maximus5/ConEmu.xml.
+			else // vendor/ConEmu.xml.default config exists, copy Cmder vendor/ConEmu.xml.default file to vendor/conemu-maximus5/ConEmu.xml.
 			{
 				if (!CopyFile(defaultCfgPath, cfgPath, FALSE))
 				{
@@ -307,6 +307,19 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 				}
 			}
 		}
+	}
+	else if (PathFileExists(cfgPath)) // vendor/conemu-maximus5/ConEmu.xml exists, copy vendor/conemu-maximus5/ConEmu.xml to config/user_conemu.xml
+	{
+		if (!CopyFile(cfgPath, userCfgPath, FALSE))
+		{
+			MessageBox(NULL,
+				(GetLastError() == ERROR_ACCESS_DENIED)
+				? L"Failed to copy vendor/conemu-maximus5/ConEmu.xml file to config/user-conemu.xml! Access Denied."
+				: L"Failed to copy vendor/conemu-maximus5/ConEmu.xml file to config/user-conemu.xml!", MB_TITLE, MB_ICONSTOP);
+			exit(1);
+		}
+
+		PathCombine(userConEmuCfgPath, userConfigDirPath, L"user-ConEmu.xml");
 	}
 	else // '-C [PATH]' was specified and 'vendor/ConEmu.xml.default' config exists, copy Cmder 'vendor/ConEmu.xml.default' file to '[user specified path]/config/user_ConEmu.xml'.
 	{

--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -247,6 +247,18 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 		}
 		else // '/c [path]' was specified, don't copy anything and use existing conemu-%COMPUTERNAME%.xml to start comemu.
 		{
+			if (use_user_cfg == false && PathFileExists(cfgPath) && !PathFileExists(cpuCfgPath)) // vendor/conemu-maximus5/ConEmu.xml file exists, copy vendor/conemu-maximus5/ConEmu.xml to config/ConEmu-%COMPUTERNAME%.xml.
+			{
+				if (!CopyFile(cfgPath, cpuCfgPath, FALSE))
+				{
+					MessageBox(NULL,
+						(GetLastError() == ERROR_ACCESS_DENIED)
+						? L"Failed to copy vendor/conemu-maximus5/ConEmu.xml file to config/ConEmu-%COMPUTERNAME%.xml! Access Denied."
+						: L"Failed to copy vendor/conemu-maximus5/ConEmu.xml file to config/ConEmu-%COMPUTERNAME%.xml!", MB_TITLE, MB_ICONSTOP);
+					exit(1);
+				}
+			}
+
 			PathCombine(userConEmuCfgPath, userConfigDirPath, L"ConEmu-%COMPUTERNAME%.xml");
 			ExpandEnvironmentStrings(userConEmuCfgPath, userConEmuCfgPath, sizeof(userConEmuCfgPath) / sizeof(userConEmuCfgPath[0]));
 		}
@@ -504,101 +516,104 @@ cmderOptions GetOption()
 	{
 
 		// MessageBox(NULL, szArgList[i], L"Arglist contents", MB_OK);
-		if (_wcsicmp(L"/c", szArgList[i]) == 0)
-		{
-			TCHAR userProfile[MAX_PATH];
-			const DWORD ret = GetEnvironmentVariable(L"USERPROFILE", userProfile, MAX_PATH);
+		if (cmderOptions.error == false) {
+			if (_wcsicmp(L"/c", szArgList[i]) == 0)
+			{
+				TCHAR userProfile[MAX_PATH];
+				const DWORD ret = GetEnvironmentVariable(L"USERPROFILE", userProfile, MAX_PATH);
 
-			wchar_t cmderCfgRoot[MAX_PATH] = { 0 };
-			PathCombine(cmderCfgRoot, userProfile, L"cmder_cfg");
+				wchar_t cmderCfgRoot[MAX_PATH] = { 0 };
+				PathCombine(cmderCfgRoot, userProfile, L"cmder_cfg");
 
-			cmderOptions.cmderCfgRoot = cmderCfgRoot;
+				cmderOptions.cmderCfgRoot = cmderCfgRoot;
 
-			if (szArgList[i + 1] != NULL && szArgList[i + 1][0] != '/')
-			{
-				cmderOptions.cmderCfgRoot = szArgList[i + 1];
-				i++;
-			}
-		}
-		else if (_wcsicmp(L"/start", szArgList[i]) == 0)
-		{
-			int len = wcslen(szArgList[i + 1]);
-			if (wcscmp(&szArgList[i + 1][len - 1], L"\"") == 0)
-			{
-				szArgList[i + 1][len - 1] = '\0';
-			}
-
-			if (PathFileExists(szArgList[i + 1]))
-			{
-				cmderOptions.cmderStart = szArgList[i + 1];
-				i++;
-			}
-			else
-			{
-				MessageBox(NULL, szArgList[i + 1], L"/START - Folder does not exist!", MB_OK);
-			}
-		}
-		else if (_wcsicmp(L"/task", szArgList[i]) == 0)
-		{
-			cmderOptions.cmderTask = szArgList[i + 1];
-			i++;
-		}
-		else if (_wcsicmp(L"/single", szArgList[i]) == 0)
-		{
-			cmderOptions.cmderSingle = true;
-		}
-		else if (_wcsicmp(L"/m", szArgList[i]) == 0)
-		{
-			cmderOptions.cmderUserCfg = false;
-		}
-		else if (_wcsicmp(L"/register", szArgList[i]) == 0)
-		{
-			cmderOptions.registerApp = true;
-			cmderOptions.unRegisterApp = false;
-			if (szArgList[i + 1] != NULL)
-			{
-				if (_wcsicmp(L"all", szArgList[i + 1]) == 0 || _wcsicmp(L"user", szArgList[i + 1]) == 0)
+				if (szArgList[i + 1] != NULL && szArgList[i + 1][0] != '/')
 				{
-					cmderOptions.cmderRegScope = szArgList[i + 1];
+					cmderOptions.cmderCfgRoot = szArgList[i + 1];
 					i++;
 				}
 			}
-		}
-		else if (_wcsicmp(L"/unregister", szArgList[i]) == 0)
-		{
-			cmderOptions.unRegisterApp = true;
-			cmderOptions.registerApp = false;
-			if (szArgList[i + 1] != NULL) 
+			else if (_wcsicmp(L"/start", szArgList[i]) == 0)
 			{
-				if (_wcsicmp(L"all", szArgList[i + 1]) == 0 || _wcsicmp(L"user", szArgList[i + 1]) == 0)
+				int len = wcslen(szArgList[i + 1]);
+				if (wcscmp(&szArgList[i + 1][len - 1], L"\"") == 0)
 				{
-					cmderOptions.cmderRegScope = szArgList[i + 1];
+					szArgList[i + 1][len - 1] = '\0';
+				}
+
+				if (PathFileExists(szArgList[i + 1]))
+				{
+					cmderOptions.cmderStart = szArgList[i + 1];
 					i++;
 				}
+				else
+				{
+					MessageBox(NULL, szArgList[i + 1], L"/START - Folder does not exist!", MB_OK);
+				}
 			}
-		}
-		else if (cmderOptions.cmderStart == L"")
-		{
-			int len = wcslen(szArgList[i]);
-			if (wcscmp(&szArgList[i][len - 1], L"\"") == 0)
+			else if (_wcsicmp(L"/task", szArgList[i]) == 0)
 			{
-				szArgList[i][len - 1] = '\0';
-			}
-		
-			if (PathFileExists(szArgList[i]))
-			{
-				cmderOptions.cmderStart = szArgList[i];
+				cmderOptions.cmderTask = szArgList[i + 1];
 				i++;
+			}
+			else if (_wcsicmp(L"/single", szArgList[i]) == 0)
+			{
+				cmderOptions.cmderSingle = true;
+			}
+			else if (_wcsicmp(L"/m", szArgList[i]) == 0)
+			{
+				cmderOptions.cmderUserCfg = false;
+			}
+			else if (_wcsicmp(L"/register", szArgList[i]) == 0)
+			{
+				cmderOptions.registerApp = true;
+				cmderOptions.unRegisterApp = false;
+				if (szArgList[i + 1] != NULL)
+				{
+					if (_wcsicmp(L"all", szArgList[i + 1]) == 0 || _wcsicmp(L"user", szArgList[i + 1]) == 0)
+					{
+						cmderOptions.cmderRegScope = szArgList[i + 1];
+						i++;
+					}
+				}
+			}
+			else if (_wcsicmp(L"/unregister", szArgList[i]) == 0)
+			{
+				cmderOptions.unRegisterApp = true;
+				cmderOptions.registerApp = false;
+				if (szArgList[i + 1] != NULL)
+				{
+					if (_wcsicmp(L"all", szArgList[i + 1]) == 0 || _wcsicmp(L"user", szArgList[i + 1]) == 0)
+					{
+						cmderOptions.cmderRegScope = szArgList[i + 1];
+						i++;
+					}
+				}
+			}
+			else if (cmderOptions.cmderStart == L"")
+			{
+				int len = wcslen(szArgList[i]);
+				if (wcscmp(&szArgList[i][len - 1], L"\"") == 0)
+				{
+					szArgList[i][len - 1] = '\0';
+				}
+
+				if (PathFileExists(szArgList[i]))
+				{
+					cmderOptions.cmderStart = szArgList[i];
+					i++;
+				}
+				else
+				{
+					MessageBox(NULL, L"Unrecognized parameter.\n\nValid options:\n\n    /c [CMDER User Root Path]\n\n    /task [ConEmu Task Name]\n\n    [/start [Start in Path] | [Start in Path]]\n\n    /single\n\n    /m\n\nor\n\n    /register [USER | ALL]\n\nor\n\n    /unregister [USER | ALL]\n", MB_TITLE, MB_OK);
+					cmderOptions.error = true;
+				}
 			}
 			else
 			{
-				MessageBox(NULL, szArgList[i], L"Folder does not exist!", MB_OK);
+				MessageBox(NULL, L"Unrecognized parameter.\n\nValid options:\n\n    /c [CMDER User Root Path]\n\n    /task [ConEmu Task Name]\n\n    [/start [Start in Path] | [Start in Path]]\n\n    /single\n\n    /m\n\nor\n\n    /register [USER | ALL]\n\nor\n\n    /unregister [USER | ALL]\n", MB_TITLE, MB_OK);
+				cmderOptions.error = true;
 			}
-		}
-		else 
-		{
-			MessageBox(NULL, L"Unrecognized parameter.\n\nValid options:\n\n    /c [CMDER User Root Path]\n\n    /task [ConEmu Task Name]\n\n    [/start [Start in Path] | [Start in Path]]\n\n    /single\n\n    /m\n\nor\n\n    /register [USER | ALL]\n\nor\n\n    /unregister [USER | ALL]\n", MB_TITLE, MB_OK);
-			cmderOptions.error = true;
 		}
 	}
 

--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -295,7 +295,7 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 					: L"Failed to copy vendor/conemu-maximus5/ConEmu.xml file to config/user-conemu.xml!", MB_TITLE, MB_ICONSTOP);
 				exit(1);
 			}
-			else // vendor/ConEmu.xml config exists, copy Cmder vendor/ConEmu.xml file to vendor/conemu-maximus5/ConEmu.xml.
+			else // vendor/ConEmu.xml config exists, copy Cmder vendor/ConEmu.xml.default file to vendor/conemu-maximus5/ConEmu.xml.
 			{
 				if (!CopyFile(defaultCfgPath, cfgPath, FALSE))
 				{

--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -149,7 +149,7 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 	}
 	
 	/*
-	Was -c [path] specified?
+	Was /c [path] specified?
 	*/
 	if (wcscmp(userConfigDirPath, L"") == 0)
 	{
@@ -220,7 +220,7 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 
 	if (PathFileExists(cpuCfgPath)) // config/ConEmu-%COMPUTERNAME%.xml file exists, use it.
 	{
-		if (cfgRoot.length() == 0) // '-C [PATH]' was NOT specified
+		if (cfgRoot.length() == 0) // '/c [path]' was NOT specified
 		{
 			if (PathFileExists(cfgPath)) // vendor/conemu-maximus5/ConEmu.xml file exists, copy vendor/conemu-maximus5/ConEmu.xml to config/ConEmu-%COMPUTERNAME%.xml.
 			{
@@ -245,7 +245,7 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 				}
 			}
 		}
-		else // '-C [PATH]' was specified, don't copy anything and use existing conemu-%COMPUTERNAME%.xml to start comemu.
+		else // '/c [path]' was specified, don't copy anything and use existing conemu-%COMPUTERNAME%.xml to start comemu.
 		{
 			PathCombine(userConEmuCfgPath, userConfigDirPath, L"ConEmu-%COMPUTERNAME%.xml");
 			ExpandEnvironmentStrings(userConEmuCfgPath, userConEmuCfgPath, sizeof(userConEmuCfgPath) / sizeof(userConEmuCfgPath[0]));
@@ -253,7 +253,7 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 	}
 	else if (PathFileExists(userCfgPath)) // config/user_conemu.xml exists, use it. 
 	{
-		if (cfgRoot.length() == 0) // '-C [PATH]' was NOT specified
+		if (cfgRoot.length() == 0) // '/c [path]' was NOT specified
 		{
 			if (PathFileExists(cfgPath)) // vendor/conemu-maximus5/ConEmu.xml exists, copy vendor/conemu-maximus5/ConEmu.xml to config/user_conemu.xml.
 			{
@@ -278,12 +278,12 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 				}
 			}
 		}
-		else // '-C [PATH]' was specified, don't copy anything and use existing user_conemu.xml to start comemu.
+		else // '/c [path]' was specified, don't copy anything and use existing user_conemu.xml to start comemu.
 		{
 			PathCombine(userConEmuCfgPath, userConfigDirPath, L"user-ConEmu.xml");
 		}
 	}
-	else if (cfgRoot.length() == 0) // '-C [PATH]' was NOT specified 
+	else if (cfgRoot.length() == 0) // '/c [path]' was NOT specified 
 	{
 		if (PathFileExists(cfgPath)) // vendor/conemu-maximus5/ConEmu.xml exists, copy vendor/conemu-maximus5/ConEmu.xml to config/user_conemu.xml
 		{
@@ -321,7 +321,7 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 
 		PathCombine(userConEmuCfgPath, userConfigDirPath, L"user-ConEmu.xml");
 	}
-	else // '-C [PATH]' was specified and 'vendor/ConEmu.xml.default' config exists, copy Cmder 'vendor/ConEmu.xml.default' file to '[user specified path]/config/user_ConEmu.xml'.
+	else // '/c [path]' was specified and 'vendor/ConEmu.xml.default' config exists, copy Cmder 'vendor/ConEmu.xml.default' file to '[user specified path]/config/user_ConEmu.xml'.
 	{
 		if ( ! CopyFile(defaultCfgPath, userCfgPath, FALSE))
 		{

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -1,6 +1,6 @@
 @echo off
 
-set cmder_init_start=%time%
+set CMDER_INIT_START=%time%
 
 :: Init Script for cmd.exe
 :: Created as part of cmder project
@@ -400,9 +400,9 @@ if "%CMDER_ALIASES%" == "1" if exist "%CMDER_ROOT%\bin\alias.bat" if exist "%CMD
 set initialConfig=
 set CMDER_CONFIGURED=1
 
-set cmder_init_end=%time%
+set CMDER_INIT_END=%time%
 
 if %time_init% gtr 0 (
-  "%cmder_root%\vendor\bin\timer.cmd" %cmder_init_start% %cmder_init_end%
+  "%cmder_root%\vendor\bin\timer.cmd" %CMDER_INIT_START% %CMDER_INIT_END%
 )
 exit /b

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -346,6 +346,7 @@ if not defined HOME set "HOME=%USERPROFILE%"
 set "initialConfig=%CMDER_ROOT%\config\user_profile.cmd"
 if exist "%CMDER_ROOT%\config\user_profile.cmd" (
     REM Create this file and place your own command in there
+    %lib_console% debug_output init.bat "Calling - %CMDER_ROOT%\config\user_profile.cmd"
     call "%CMDER_ROOT%\config\user_profile.cmd"
 )
 
@@ -353,6 +354,7 @@ if defined CMDER_USER_CONFIG (
   set "initialConfig=%CMDER_USER_CONFIG%\user_profile.cmd"
   if exist "%CMDER_USER_CONFIG%\user_profile.cmd" (
       REM Create this file and place your own command in there
+      %lib_console% debug_output init.bat "Calling - %CMDER_USER_CONFIG%\user_profile.cmd
       call "%CMDER_USER_CONFIG%\user_profile.cmd"
   )
 )

--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -128,9 +128,14 @@ if (-not (test-path "$ENV:CMDER_ROOT\config\profile.d")) {
 }
 
 pushd $ENV:CMDER_ROOT\config\profile.d
-foreach ($x in Get-ChildItem *.ps1) {
+foreach ($x in Get-ChildItem *.psm1) {
   # write-host write-host Sourcing $x
   Import-Module $x
+}
+
+foreach ($x in Get-ChildItem *.ps1) {
+  # write-host write-host Sourcing $x
+  . $x
 }
 popd
 
@@ -138,9 +143,14 @@ popd
 # to source them at startup.  Requires using cmder.exe /C [cmder_user_root_path] argument
 if ($ENV:CMDER_USER_CONFIG -ne "" -and (test-path "$ENV:CMDER_USER_CONFIG\profile.d")) {
     pushd $ENV:CMDER_USER_CONFIG\profile.d
-    foreach ($x in Get-ChildItem *.ps1) {
+    foreach ($x in Get-ChildItem *.psm1) {
       # write-host write-host Sourcing $x
       Import-Module $x
+    }
+
+    foreach ($x in Get-ChildItem *.ps1) {
+      # write-host write-host Sourcing $x
+      . $x
     }
     popd
 }
@@ -153,7 +163,7 @@ if (test-path "$env:CMDER_ROOT\config\user-profile.ps1") {
 $CmderUserProfilePath = Join-Path $env:CMDER_ROOT "config\user_profile.ps1"
 if (Test-Path $CmderUserProfilePath) {
     # Create this file and place your own command in there.
-    Import-Module "$CmderUserProfilePath"
+    . "$CmderUserProfilePath" # user_profile.ps1 is not a module DO NOT USE import-module
 }
 
 if ($ENV:CMDER_USER_CONFIG) {
@@ -166,7 +176,7 @@ if ($ENV:CMDER_USER_CONFIG) {
 
     $CmderUserProfilePath = Join-Path $ENV:CMDER_USER_CONFIG "user_profile.ps1"
     if (Test-Path $CmderUserProfilePath) {
-      Import-Module "$CmderUserProfilePath"
+      . "$CmderUserProfilePath" # user_profile.ps1 is not a module DO NOT USE import-module
     }
 }
 


### PR DESCRIPTION
@CollinChaffin Can you test this?  Related to #695

### Cmder Shared Install Multi User Enhancement

This PR enhances the way Cmder.exe launches ConEmu when `/c [path]` is used on the command line to enable using a shared install of Cmder.

Sorry for the long explanation but I felt it was necessary.

### Current Behavior

`Cmder.exe` does some `ConEmu.xml` configuration magic to retain user settings modifications done in the ConEmu GUI.   When `Cmder.exe` is started it does the following logic:

1. If `%CMDER_ROOT%\config\ConEmu-%COMPUTERNAME%.xml` file exists
    1. If `%CMDER_ROOT%\vendor\conemu-maximus5\ConEmu.xml` file exists 
        1. Copy `%CMDER_ROOT%\vendor\conemu-maximus5\ConEmu.xml` to `%CMDER_ROOT%config/ConEmu-%COMPUTERNAME%.xml` to save any ConEmu GUI settings changes from previous sessions so they can be used in future sessions.
    1. Else
        1. Copy `%CMDER_ROOT%\config\ConEmu-%COMPUTERNAME%.xml` to `%CMDER_ROOT%\vendor\conemu-maximus5\ConEmu.xml`.  This is usually done following an upgrade of Cmder to reapply previously backed up configuration.
1. Else if `%CMDER_ROOT%\config\user_conemu.xml` exists
    1. If %CMDER_ROOT%\vendor\conemu-maximus5/ConEmu.xml exists
        1. Copy `%CMDER_ROOT%\vendor\conemu-maximus5\ConEmu.xml` to `%CMDER_ROOT%\config\user_conemu.xml` to save any ConEmu GUI settings changes from previous sessions so they can be used in future sessions.
    1. Else 
        1. Copy `%CMDER_ROOT%\config\user-conemu.xml to `%CMDER_ROOT%\vendor\conemu-maximus5\ConEmu.xml`.  This is usually done following an upgrade of Cmder to reapply previously backed up configuration.
1. Else
    1. Copy `%CMDER_ROOT%\vendor\ConEmu.xml.default` to `%CMDER_ROOT%\vendor\conemu-maximus5\ConEmu.xml`.  This happens on a brand new Cmder install whaere no previously backed up config exists.

This is done because the maintainer of ConEmu recommends leaving the ConEmu.xml file in the program folder.  This results in all user init scripts and config are stored in a single place, the `%CMDER_ROOT%\config` folder.
 
### The Problem when you use `/c [path]` command line argument.

The current behavior works great for a single user because all config is stored in `%CMDER_ROOT%\config` ConEmu runs using the `%CMDER_ROOT%\vendor\conemu-maximus5\ConEmu.xml` file that is backed up on launch to `%CMDER_ROOT%\config`.

This is not so great for a use case where a shared install of Cmder would be beneficial.  Different users WILL want different settings based on personal preference.  The default behavior does not allow this but the `/c [path]` currently partially enabled using a shared install.

The storage of user init scripts and config changes using this command line switch.  Init scripts and conemu.xml backups are stored in the `[user specified path]\config` instead of `%CMDER_ROOT%\config`.  This allows the following:

`Cmder.exe` can now use the `%CMDER_ROOT%\config` init scripts to allow a shared set of binaries and some shared configuration.  It can now also apply user specific configuration after the shared configuration allowing users to have their own settings - ALMOST.

The problem is that Cmder still applies the same logic detailed above or handling ConEmu.xml config so SOME user unique config is possible but not all.  It requires that all users have write access to the `%CMDER_ROOT%\vendor\conemu-maximus5\ConEmu.xml`.  This can result in user settings change contention in ConEmu.

This PR fixes the last issue and enables true shared install with complete user customization.

### The Difference in this PR.

When `-c [path]` is used to launch Cmder it does everything mentioned above but the logic handling ConEmu.xml backups changes:

1. If `/c [path]` is used
   1. If `[path]\config\ConEmu-%COMPUTERNAME%.xml` file exists
      1. Use `[path]\config\ConEmu-%COMPUTERNAME%.xml` to launch `ConEmu.exe`
   1. Else if `[path]\config\user_conemu.xml` exists
      1. Use `[path]\config\user_conemu.xml` to launch `ConEmu.exe`
   1. Else
       1. Copy `%CMDER_ROOT%\vendor\ConEmu.xml.default` to `[path]\config\user_conemu.xml`
       1. Use `[path]\config\user_conemu.xml` to launch `ConEmu.exe`

This way no backup is required because changes in the GUI are written directly to the file in `[path]\config`
