### PR TITLE
Improve LANG env var detection

### DIFF
--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -243,9 +243,16 @@ if defined GIT_INSTALL_ROOT (
 
     :: define SVN_SSH so we can use git svn with ssh svn repositories
     if not defined SVN_SSH set "SVN_SSH=%GIT_INSTALL_ROOT:\=\\%\\bin\\ssh.exe"
-
-    for /F "delims=" %%F in ('env /usr/bin/locale -uU 2') do (
-        set "LANG=%%F"
+    
+    if not defined LANG (
+        :: Find locale.exe: From the git install root, from the path, using the git installed env, or fallback using the env from the path.
+        if not defined git_locale if exist "!GIT_INSTALL_ROOT!\usr\bin\locale.exe" set git_locale="!GIT_INSTALL_ROOT!\usr\bin\locale.exe"
+        if not defined git_locale for /F "delims=" %%F in ('where locale.exe 2^>nul') do (if not defined git_locale  set git_locale="%%F")
+        if not defined git_locale if exist "!GIT_INSTALL_ROOT!\usr\bin\env.exe" set git_locale="!GIT_INSTALL_ROOT!\usr\bin\env.exe" /usr/bin/locale
+        if not defined git_locale set git_locale=env /usr/bin/locale
+        for /F "delims=" %%F in ('!git_locale! -uU 2') do (
+            set "LANG=%%F"
+        )
     )
 )
 


### PR DESCRIPTION
Change the detection of the LANG env var:
- only try to detect if it does not set yet
- search for a proper locale.exe
-- prefer locale.exe from the git install root
-- check the path for a locale.exe
-- use git installed env.exe with /usr/bin/locale`
-- fallback to the old env /usr/bin/locale

Should we actually always set the LANG env var, even if the detection fails? This is what they did in [Hyper](https://github.com/zeit/hyper/issues/346).

Fixes #1956
