### PR TITLE
Add /git_no_unix switch to init.bat to prevent adding !GIT_INSTALL_ROOT!\usr\bin to PATH

### DIFF
--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -14,6 +14,8 @@ set debug_output=0
 set time_init=0
 set fast_init=0
 set max_depth=1
+:: Add *nix tools to end of path. 0 turns off *nix tools.
+set nix_tools=1
 set "CMDER_USER_FLAGS= "
 
 :: Find root dir
@@ -78,6 +80,16 @@ call "%cmder_root%\vendor\lib\lib_profile"
         ) else (
             %lib_console% show_error "The Git install root folder "%~2", you specified does not exist!"
             exit /b
+        )
+    ) else if /i "%1"=="/nix_tools" (
+        if "%2" equ "0" (
+            REM Do not add *nix tools to path
+            set nix_tools=0
+            shift
+        ) else if "%2" equ "1" (
+            REM Add *nix tools to end of path
+            set nix_tools=1
+            shift
         )
     ) else if /i "%1" == "/home" (
         if exist "%~2" (
@@ -239,7 +251,9 @@ if defined GIT_INSTALL_ROOT (
     ) else if exist "!GIT_INSTALL_ROOT!\mingw64" (
         %lib_path% enhance_path "!GIT_INSTALL_ROOT!\mingw64\bin" append
     )
-    %lib_path% enhance_path "!GIT_INSTALL_ROOT!\usr\bin" append
+    if %nix_tools% equ 1 (
+        %lib_path% enhance_path "!GIT_INSTALL_ROOT!\usr\bin" append
+    )
 
     :: define SVN_SSH so we can use git svn with ssh svn repositories
     if not defined SVN_SSH set "SVN_SSH=%GIT_INSTALL_ROOT:\=\\%\\bin\\ssh.exe"


### PR DESCRIPTION
Adding all the unix tools to the path prevents some programs (Vivado) from working for me.