### PR TITLE
Fix post-install.bat not running and deleting itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+* Pull Request: [#2106](https://github.com/cmderdev/cmder/pull/2106)
+  * Portable Git requires running `post-install.bat` which deletes itself when done.  This was not happening.
 * Pull Request: [#2002](https://github.com/cmderdev/cmder/pull/2002)
   * Updated the HG prompt code to use the '-ib' option to 'hg id' so the branch name is always available, regardless of the state of the working copy
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Pull Request: [#2106](https://github.com/cmderdev/cmder/pull/2106)
   * Portable Git requires running `post-install.bat` which deletes itself when done.  This was not happening.
+  * Resolves [#2105](https://github.com/cmderdev/cmder/issues/2105) 
 * Pull Request: [#2002](https://github.com/cmderdev/cmder/pull/2002)
   * Updated the HG prompt code to use the '-ib' option to 'hg id' so the branch name is always available, regardless of the state of the working copy
 

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -369,9 +369,9 @@ call "%user_aliases%"
 :: Basically we need to execute this post-install.bat because we are
 :: manually extracting the archive rather than executing the 7z sfx
 if exist "%GIT_INSTALL_ROOT%\post-install.bat" (
-    %lib_console% verbose_output "Running Git for Windows one time Post Install...."
+    echo Running Git for Windows one time Post Install....
     pushd "%GIT_INSTALL_ROOT%\"
-    "%GIT_INSTALL_ROOT%\git-bash.exe" --no-needs-console --hide --no-cd --command=post-install.bat
+    "%GIT_INSTALL_ROOT%\git-cmd.exe" --no-needs-console --no-cd --command=post-install.bat
     popd
 )
 


### PR DESCRIPTION
### Fixes


 * Pull Request: [#2106](https://github.com/cmderdev/cmder/pull/2106)
  * Portable Git requires running `post-install.bat` which deletes itself when done.  This was not happening.
  * Resolves [#2105](https://github.com/cmderdev/cmder/issues/2105) 