### PR TITLE
Add bare doubledash command line option

### DIFF
--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -633,6 +633,20 @@ cmderOptions GetOption()
 				cmderOptions.cmderConEmuArgs = szArgList[i + 1];
 				i++;
 			}
+			/* All remaining args are passed to conemu */
+			else if (_wcsicmp(L"--", szArgList[i]) == 0)
+			{
+				i++;
+				for (int j = i; j < argCount; j++)
+				{
+					if (j != i) 
+					{
+						cmderOptions.cmderConEmuArgs += L" ";
+					}
+					cmderOptions.cmderConEmuArgs += szArgList[j];
+				}
+				break;
+			}
 			else if (cmderOptions.cmderStart == L"")
 			{
 				int len = wcslen(szArgList[i]);


### PR DESCRIPTION
The '--' parameter is a common POSIX-style option.  All command-line parameters after the double dash will be joined by a space and forwarded to conemu. 

This greatly simplifies launching Cmder with project-specific settings without creating a Task for each project. It also improves the '/x' option because you do not have to worry about escaping quotes.

**Example usage:**
```batch
cmder -- -runlist cmd -new_console:t:"MyTest" /k "echo one" "|||" cmd -new_console:t:"Test2" /k "echo two"
```
In the example above, two tabs are created and each echo a different word.  The "|||" is in quotes so  that cmd.exe would not think it was a pipe.

**Note**:
I did not remove the "/x" option, but it may not be needed now.