### PR TITLE
Bare doubledash

### DIFF
--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -543,6 +543,20 @@ struct cmderOptions
 
 cmderOptions GetOption()
 {
+	// Pull doubledash arguments directly from the commandline
+	// so that quotemarks  and spaces are retained.
+	// To avoid interpreting a doubledash embedded in a string as a
+	// command argument, wait until we find the doubledash in the 
+	// szArgList before adding it to the cmderOptions.
+	
+	std::wstring doubledash_args = L"";
+	std::wstring cmdline = std::wstring(GetCommandLineW());
+	auto doubledash = cmdline.find(L" -- ");
+	if (doubledash != std::string::npos)
+	{
+		doubledash_args = cmdline.substr(doubledash + 4);
+	}
+
 	cmderOptions cmderOptions;
 	LPWSTR *szArgList;
 	int argCount;
@@ -633,18 +647,10 @@ cmderOptions GetOption()
 				cmderOptions.cmderConEmuArgs = szArgList[i + 1];
 				i++;
 			}
-			/* All remaining args are passed to conemu */
+			/* Bare double dash, remaining commandline is for conemu */
 			else if (_wcsicmp(L"--", szArgList[i]) == 0)
 			{
-				i++;
-				for (int j = i; j < argCount; j++)
-				{
-					if (j != i) 
-					{
-						cmderOptions.cmderConEmuArgs += L" ";
-					}
-					cmderOptions.cmderConEmuArgs += szArgList[j];
-				}
+				cmderOptions.cmderConEmuArgs = doubledash_args;
 				break;
 			}
 			else if (cmderOptions.cmderStart == L"")

--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -543,20 +543,6 @@ struct cmderOptions
 
 cmderOptions GetOption()
 {
-	// Pull doubledash arguments directly from the commandline
-	// so that quotemarks  and spaces are retained.
-	// To avoid interpreting a doubledash embedded in a string as a
-	// command argument, wait until we find the doubledash in the 
-	// szArgList before adding it to the cmderOptions.
-	
-	std::wstring doubledash_args = L"";
-	std::wstring cmdline = std::wstring(GetCommandLineW());
-	auto doubledash = cmdline.find(L" -- ");
-	if (doubledash != std::string::npos)
-	{
-		doubledash_args = cmdline.substr(doubledash + 4);
-	}
-
 	cmderOptions cmderOptions;
 	LPWSTR *szArgList;
 	int argCount;
@@ -650,7 +636,13 @@ cmderOptions GetOption()
 			/* Bare double dash, remaining commandline is for conemu */
 			else if (_wcsicmp(L"--", szArgList[i]) == 0)
 			{
-				cmderOptions.cmderConEmuArgs = doubledash_args;
+				std::wstring doubledash_args = L"";
+				std::wstring cmdline = std::wstring(GetCommandLineW());
+				auto doubledash = cmdline.find(L" -- ");
+				if (doubledash != std::string::npos)
+				{
+					cmderOptions.cmderConEmuArgs = cmdline.substr(doubledash + 4);
+				}
 				break;
 			}
 			else if (cmderOptions.cmderStart == L"")

--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -636,7 +636,6 @@ cmderOptions GetOption()
 			/* Bare double dash, remaining commandline is for conemu */
 			else if (_wcsicmp(L"--", szArgList[i]) == 0)
 			{
-				std::wstring doubledash_args = L"";
 				std::wstring cmdline = std::wstring(GetCommandLineW());
 				auto doubledash = cmdline.find(L" -- ");
 				if (doubledash != std::string::npos)

--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -633,6 +633,20 @@ cmderOptions GetOption()
 				cmderOptions.cmderConEmuArgs = szArgList[i + 1];
 				i++;
 			}
+			/* All remaining args are passed to conemu */
+			else if (_wcsicmp(L"--", szArgList[i]) == 0)
+			{
+				i++;
+				for (int j = i; j < argCount; j++)
+				{
+					if (j != i) 
+					{
+						cmderOptions.cmderConEmuArgs += L" ";
+					}
+					cmderOptions.cmderConEmuArgs += szArgList[j];
+				}
+				break;
+			}
 			else if (cmderOptions.cmderStart == L"")
 			{
 				int len = wcslen(szArgList[i]);


### PR DESCRIPTION
Add a "--" command line option so Cmder can be launched with any conemu command.  The command line after the double dash is forwarded as is. Quotes and spaces are retained so that there is no need for complex escaping.

It greatly simplifies launching project-specific consoles/commands without requiring that Tasks be created for each project.

**For example:**
This is a batch file that I am using in a real project where I am updating a software package. This batch file launches Cmder with (1) a console running Docker with the original software, (2) a console running Docker with the new backend software, (3) a console running a development node server, (4) a console that I work from.
```batch
e:\apps\tools\cmder\cmder.exe -- -runlist ^
cmd -new_console:d:"E:\Projects\mfd\original-docker":t:"Docker Original" /k "addpath docker && docker-compose up" "|||" ^
cmd -new_console:d:"E:\Projects\mfd\newui":t:"Docker NewUI" /k "addpath docker &&  docker-compose up" "|||" ^
cmd -new_console:d:"E:\Projects\mfd\newui\frontend":t:"Yarn Start" /k "addpath node &&  yarn start" "|||" ^
cmd -new_console:d:"E:\Projects\mfd\newui\frontend":t:"newui" /k "addpath node"

```
It can have spaces in paths and names without escapes.

**Note:**
I have not updated the Readme or the popup help window.  I have not removed the "/x" option, though it may not be needed now.