### PR TITLE
Git opt out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ vendor/*/*
 !vendor/bin/*
 !vendor/lib/*
 !vendor/*
-!vendor/psmodules/PsGet
+!vendor/psmodules/*
 
 config/*
 !config/Readme.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Fixes
 
+* Fix #2191: profile.ps1: CheckGit does not export $gitLoaded
 * Fix #2192: Set default prompt hooks before loading user profile
 * Fix #2097, #1899: powershell foreground color changing to green
 * Fix #1979: Update Clink Completions to 0.3.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Adds
 
-* #2197, #1364, #447 Add ability to disable git status either globally or for individual repos in `cmd::cmder*` sessions.
+* #2197, #1364, #447 Add ability to disable git status either globally or for individual repos.
   * To disable git status globally add the following to `~/.gitconfig` or locally for a single repo `[repo]/.git/config`:
 
     ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## [1.3.13](https://github.com/cmderdev/cmder/tree/v1.3.12) (2019-11-3)
+## [1.3.13](https://github.com/cmderdev/cmder/tree/v1.3.12) (2019-11-03)
 
 ### Adds
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,17 @@
 
 ## [Unreleased]
 
-## [1.3.13](https://github.com/cmderdev/cmder/tree/v1.3.12) (2019-10-27)
+## [1.3.13](https://github.com/cmderdev/cmder/tree/v1.3.12) (2019-11-3)
 
 ### Adds
+
+* #2197, #1364, #447 Add ability to disable git status either globally or for individual repos in `cmd::cmder*` sessions.
+  * To disable git status globally add the following to `~/.gitconfig` or locally for a single repo `[repo]/.git/config`:
+
+    ```
+    [cmder]
+      status = false
+    ```
 
 * #2174 `--` Syntax to pass command line options to Conemu.
 * Disable Clink Logging

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ _(Some shortcuts are not yet documented, though they exist - please document the
 ### Access to multiple shells in one window using tabs
 You can open multiple tabs each containing one of the following shells:
 
-| Task                | Shell          | Description                                                                                                  |
-| ----                | -----          | -----------                                                                                                  |
+| Task                | Shell            | Description                                                                                                  |
+| ----                | -----            | -----------                                                                                                  |
 | Cmder               | `cmd.exe`        | Windows `cmd.exe` shell enhanced with Git, Git aware prompt, Clink (GNU Readline), and Aliases.              |
 | Cmder as Admin      | `cmd.exe`        | Administrative Windows `cmd.exe` Cmder shell.                                                                |
 | PowerShell          | `powershell.exe` | Windows PowerShell enhanced with Git and Git aware prompt .                                                  |
@@ -175,6 +175,17 @@ You can write `*.cmd|*.bat`, `*.ps1`, and `*.sh` scripts and just drop them in t
 | Cmder         | `%CMDER_ROOT%\config\profile.d\*.bat and *.cmd` |
 | PowerShell    | `$ENV:CMDER_ROOT\config\profile.d\*.ps1`        |
 | Bash/Mintty   | `$CMDER_ROOT/config/profile.d/*.sh`                 |
+
+#### Git Status Opt-Out for `Cmd::Cmder*` Sessions
+
+ To disable git status globally add the following to `~/.gitconfig` or locally for a single repo `[repo]/.git/config`.
+
+ *Note: theis configuration is not portable*
+
+ ```
+ [cmder]
+   status = false
+ ```
 
 ### Aliases
 #### Cmder(`Cmd.exe`) Aliases

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ You can write `*.cmd|*.bat`, `*.ps1`, and `*.sh` scripts and just drop them in t
 
  To disable git status globally add the following to `~/.gitconfig` or locally for a single repo `[repo]/.git/config`.
 
- *Note: theis configuration is not portable*
+ *Note: This configuration is not portable*
 
  ```
  [cmder]

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ You can write `*.cmd|*.bat`, `*.ps1`, and `*.sh` scripts and just drop them in t
 
 #### Git Status Opt-Out for `Cmd::Cmder*` Sessions
 
- To disable Cmder prompt git status globally add the following to `~/.gitconfig` or locally for a single repo `[repo]/.git/config`.
+ To disable Cmder prompt git status globally add the following to `~/.gitconfig` or locally for a single repo `[repo]/.git/config` and start a new session.
 
  *Note: This configuration is not portable*
 

--- a/README.md
+++ b/README.md
@@ -164,19 +164,19 @@ Single user portable configuration is possible using the cmder specific shell co
 | ------------- | ----------------------------------------- |
 | Cmder         | `%CMDER_ROOT%\config\user_profile.cmd`    |
 | PowerShell    | `$ENV:CMDER_ROOT\config\user_profile.ps1` |
-| Bash/Mintty   | `$CMDER_ROOT/config/user_profile.sh`        |
+| Bash/Mintty   | `$CMDER_ROOT/config/user_profile.sh`      |
 
 Note: Bash and Mintty sessions will also source the `$HOME/.bashrc` file if it exists after it sources `$CMDER_ROOT/config/user_profile.sh`.
 
 You can write `*.cmd|*.bat`, `*.ps1`, and `*.sh` scripts and just drop them in the `%CMDER_ROOT%\config\profile.d` folder to add startup config to Cmder.
 
-| Shell         | Cmder `Profile.d` Scripts                         |
-| ------------- | --------------------------------------------------|
-| Cmder         | `%CMDER_ROOT%\config\profile.d\*.bat and *.cmd` |
-| PowerShell    | `$ENV:CMDER_ROOT\config\profile.d\*.ps1`        |
-| Bash/Mintty   | `$CMDER_ROOT/config/profile.d/*.sh`                 |
+| Shell         | Cmder `Profile.d` Scripts                          |
+| ------------- | -------------------------------------------------- |
+| Cmder         | `%CMDER_ROOT%\config\profile.d\*.bat and *.cmd`    |
+| PowerShell    | `$ENV:CMDER_ROOT\config\profile.d\*.ps1`           |
+| Bash/Mintty   | `$CMDER_ROOT/config/profile.d/*.sh`                |
 
-#### Git Status Opt-Out for `Cmd::Cmder*` Sessions
+#### Git Status Opt-Out
 
  To disable Cmder prompt git status globally add the following to `~/.gitconfig` or locally for a single repo `[repo]/.git/config` and start a new session.
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ You can write `*.cmd|*.bat`, `*.ps1`, and `*.sh` scripts and just drop them in t
 
 #### Git Status Opt-Out for `Cmd::Cmder*` Sessions
 
- To disable git status globally add the following to `~/.gitconfig` or locally for a single repo `[repo]/.git/config`.
+ To disable Cmder prompt git status globally add the following to `~/.gitconfig` or locally for a single repo `[repo]/.git/config`.
 
  *Note: This configuration is not portable*
 

--- a/vendor/clink.lua
+++ b/vendor/clink.lua
@@ -280,6 +280,24 @@ local function get_svn_status()
     return true
 end
 
+---
+-- Get the status of working dir
+-- @return {bool}
+---
+local function get_git_status_setting()
+    gitStatusSetting = io.popen("git config cmder.status")
+
+    for line in gitStatusSetting:lines() do
+        if string.match(line, 'false') then
+          gitStatusSetting:close()
+          return false
+        end
+    end
+    gitStatusSetting:close()
+
+    return true
+end
+
 local function git_prompt_filter()
 
     -- Colors for git status
@@ -290,27 +308,30 @@ local function git_prompt_filter()
     }
 
     local git_dir = get_git_dir()
-    if git_dir then
-        -- if we're inside of git repo then try to detect current branch
-        local branch = get_git_branch(git_dir)
-        local color
-        if branch then
-            -- Has branch => therefore it is a git folder, now figure out status
-            local gitStatus = get_git_status()
-            local gitConflict = get_git_conflict()
 
-            color = colors.dirty
-            if gitStatus then
-                color = colors.clean
-            end
+    if get_git_status_setting() then
+      if git_dir then
+          -- if we're inside of git repo then try to detect current branch
+          local branch = get_git_branch(git_dir)
+          local color
+          if branch then
+              -- Has branch => therefore it is a git folder, now figure out status
+              local gitStatus = get_git_status()
+              local gitConflict = get_git_conflict()
 
-            if gitConflict then
-                color = colors.conflict
-            end 
+              color = colors.dirty
+              if gitStatus then
+                  color = colors.clean
+              end
 
-            clink.prompt.value = string.gsub(clink.prompt.value, "{git}", color.."("..verbatim(branch)..")")
-            return false
-        end
+              if gitConflict then
+                  color = colors.conflict
+              end 
+
+              clink.prompt.value = string.gsub(clink.prompt.value, "{git}", color.."("..verbatim(branch)..")")
+              return false
+          end
+      end
     end
 
     -- No git present or not in git file

--- a/vendor/git-prompt.sh
+++ b/vendor/git-prompt.sh
@@ -1,3 +1,14 @@
+function getGitStatusSetting() {
+  gitStatusSetting=$(git config cmder.status 2>/dev/null)  
+
+  if [[ -n ${gitStatusSetting} ]] && [[ ${gitStatusSetting} == false ]]
+  then
+    echo false
+  else
+    echo true
+  fi
+}
+
 if test -f /etc/profile.d/git-sdk.sh
 then
   TITLEPREFIX=SDK-${MSYSTEM#MINGW}
@@ -7,7 +18,10 @@ fi
 
 if test -f ~/.config/git/git-prompt.sh
 then
-  . ~/.config/git/git-prompt.sh
+  if [[ $(getGitStatusSetting) == true ]]
+  then
+    . ~/.config/git/git-prompt.sh
+  fi
 else
   PS1='\[\033]0;$MSYSTEM:${PWD//[^[:ascii:]]/?}\007\]' # set window title
   # PS1="$PS1"'\n'                 # new line
@@ -26,9 +40,12 @@ else
     if test -f "$COMPLETION_PATH/git-prompt.sh"
     then
       . "$COMPLETION_PATH/git-completion.bash"
-      . "$COMPLETION_PATH/git-prompt.sh"
-      PS1="$PS1"'\[\033[36m\]'  # change color to cyan
-      PS1="$PS1"'`__git_ps1`'   # bash function
+      if [[ $(getGitStatusSetting) == true ]]
+      then
+        . "$COMPLETION_PATH/git-prompt.sh"
+        PS1="$PS1"'\[\033[36m\]'  # change color to cyan
+        PS1="$PS1"'`__git_ps1`'   # bash function
+      fi
     fi
   fi
   PS1="$PS1"'\[\033[0m\]'        # change color

--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -57,7 +57,6 @@ if (Get-Module PSReadline -ErrorAction "SilentlyContinue") {
 }
 
 # Pre assign default prompt hooks so the first run of cmder gets a working prompt.
-$gitLoaded = $false
 $env:gitLoaded = $false
 [ScriptBlock]$PrePrompt = {}
 [ScriptBlock]$PostPrompt = {}

--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -32,51 +32,11 @@ $moduleInstallerAvailable = [bool](Get-Command -Name 'Install-Module' -ErrorActi
 # Add Cmder modules directory to the autoload path.
 $CmderModulePath = Join-path $PSScriptRoot "psmodules/"
 
+$CmderFunctions =  Join-Path $CmderModulePath "Cmder.ps1"
+. $CmderFunctions
+
 if(-not $moduleInstallerAvailable -and -not $env:PSModulePath.Contains($CmderModulePath) ){
     $env:PSModulePath = $env:PSModulePath.Insert(0, "$CmderModulePath;")
-}
-
-function Configure-Git($GIT_INSTALL_ROOT){
-  $env:Path += $(";" + $GIT_INSTALL_ROOT + "\cmd")
-
-  # Add "$GIT_INSTALL_ROOT\usr\bin" to the path if exists and not done already
-  $GIT_INSTALL_ROOT_ESC=$GIT_INSTALL_ROOT.replace('\','\\')
-  if ((test-path "$GIT_INSTALL_ROOT\usr\bin") -and -not ($env:path -match "$GIT_INSTALL_ROOT_ESC\\usr\\bin")) {
-      $env:path = "$env:path;$GIT_INSTALL_ROOT\usr\bin"
-  }
-
-  # Add "$GIT_INSTALL_ROOT\mingw[32|64]\bin" to the path if exists and not done already
-  if ((test-path "$GIT_INSTALL_ROOT\mingw32\bin") -and -not ($env:path -match "$GIT_INSTALL_ROOT_ESC\\mingw32\\bin")) {
-      $env:path = "$env:path;$GIT_INSTALL_ROOT\mingw32\bin"
-  } elseif ((test-path "$GIT_INSTALL_ROOT\mingw64\bin") -and -not ($env:path -match "$GIT_INSTALL_ROOT_ESC\\mingw64\\bin")) {
-      $env:path = "$env:path;$GIT_INSTALL_ROOT\mingw64\bin"
-  }
-}
-
-$gitLoaded = $false
-function Import-Git($Loaded){
-    if($Loaded) { return }
-    $GitModule = Get-Module -Name Posh-Git -ListAvailable
-    if($GitModule | select version | where version -le ([version]"0.6.1.20160330")){
-        Import-Module Posh-Git > $null
-    }
-    if(-not ($GitModule) ) {
-        Write-Warning "Missing git support, install posh-git with 'Install-Module posh-git' and restart cmder."
-    }
-    # Make sure we only run once by alawys returning true
-    return $true
-}
-
-function checkGit($Path) {
-    if (Test-Path -Path (Join-Path $Path '.git') ) {
-        $gitLoaded = Import-Git $gitLoaded
-        Write-VcsStatus
-        return
-    }
-    $SplitPath = split-path $path
-    if ($SplitPath) {
-        checkGit($SplitPath)
-    }
 }
 
 try {
@@ -97,6 +57,8 @@ if (Get-Module PSReadline -ErrorAction "SilentlyContinue") {
 }
 
 # Pre assign default prompt hooks so the first run of cmder gets a working prompt.
+$gitLoaded = $false
+$env:gitLoaded = $false
 [ScriptBlock]$PrePrompt = {}
 [ScriptBlock]$PostPrompt = {}
 [ScriptBlock]$CmderPrompt = {

--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -67,6 +67,7 @@ $env:gitLoaded = $false
     if (get-command git -erroraction silentlycontinue) {
         checkGit($pwd.ProviderPath)
     }
+    Microsoft.PowerShell.Utility\Write-Host "`nλ " -NoNewLine -ForegroundColor "DarkGray"
 }
 
 # Enhance Path
@@ -156,7 +157,6 @@ if ( $(get-command prompt).Definition -match 'PS \$\(\$executionContext.SessionS
       $host.UI.RawUI.WindowTitle = Microsoft.PowerShell.Management\Split-Path $pwd.ProviderPath -Leaf
       PrePrompt | Microsoft.PowerShell.Utility\Write-Host -NoNewline
       CmderPrompt
-      Microsoft.PowerShell.Utility\Write-Host "`nλ " -NoNewLine -ForegroundColor "DarkGray"
       PostPrompt | Microsoft.PowerShell.Utility\Write-Host -NoNewline
       $global:LASTEXITCODE = $realLASTEXITCODE
       return " "

--- a/vendor/psmodules/Cmder.ps1
+++ b/vendor/psmodules/Cmder.ps1
@@ -15,7 +15,7 @@ function Configure-Git($GIT_INSTALL_ROOT){
   }
 }
 
-function Import-Git($Loaded){
+function Import-Git(){
     $GitModule = Get-Module -Name Posh-Git -ListAvailable
     if($GitModule | select version | where version -le ([version]"0.6.1.20160330")){
         Import-Module Posh-Git > $null
@@ -30,7 +30,7 @@ function Import-Git($Loaded){
 function checkGit($Path) {  
     if (Test-Path -Path (Join-Path $Path '.git') ) {
       if($env:gitLoaded -eq 'false') {
-        $env:gitLoaded = Import-Git $gitLoaded
+        $env:gitLoaded = Import-Git
       }
       Write-VcsStatus
       return

--- a/vendor/psmodules/Cmder.ps1
+++ b/vendor/psmodules/Cmder.ps1
@@ -32,7 +32,11 @@ function checkGit($Path) {
       if($env:gitLoaded -eq 'false') {
         $env:gitLoaded = Import-Git
       }
-      Write-VcsStatus
+
+      if (getGitStatusSetting -eq $true) {
+        Write-VcsStatus
+      }
+
       return
     }
     $SplitPath = split-path $path
@@ -41,4 +45,12 @@ function checkGit($Path) {
     }
 }
 
+function getGitStatusSetting() {
+    $gitStatus = (git config cmder.status) | out-string
 
+    if (($gitStatus -replace "`n" -replace "`r") -eq "false") {
+        return $false
+    } else {
+        return $true
+    }
+}

--- a/vendor/psmodules/Cmder.ps1
+++ b/vendor/psmodules/Cmder.ps1
@@ -1,0 +1,44 @@
+function Configure-Git($GIT_INSTALL_ROOT){
+  $env:Path += $(";" + $GIT_INSTALL_ROOT + "\cmd")
+
+  # Add "$GIT_INSTALL_ROOT\usr\bin" to the path if exists and not done already
+  $GIT_INSTALL_ROOT_ESC=$GIT_INSTALL_ROOT.replace('\','\\')
+  if ((test-path "$GIT_INSTALL_ROOT\usr\bin") -and -not ($env:path -match "$GIT_INSTALL_ROOT_ESC\\usr\\bin")) {
+      $env:path = "$env:path;$GIT_INSTALL_ROOT\usr\bin"
+  }
+
+  # Add "$GIT_INSTALL_ROOT\mingw[32|64]\bin" to the path if exists and not done already
+  if ((test-path "$GIT_INSTALL_ROOT\mingw32\bin") -and -not ($env:path -match "$GIT_INSTALL_ROOT_ESC\\mingw32\\bin")) {
+      $env:path = "$env:path;$GIT_INSTALL_ROOT\mingw32\bin"
+  } elseif ((test-path "$GIT_INSTALL_ROOT\mingw64\bin") -and -not ($env:path -match "$GIT_INSTALL_ROOT_ESC\\mingw64\\bin")) {
+      $env:path = "$env:path;$GIT_INSTALL_ROOT\mingw64\bin"
+  }
+}
+
+function Import-Git($Loaded){
+    $GitModule = Get-Module -Name Posh-Git -ListAvailable
+    if($GitModule | select version | where version -le ([version]"0.6.1.20160330")){
+        Import-Module Posh-Git > $null
+    }
+    if(-not ($GitModule) ) {
+        Write-Warning "Missing git support, install posh-git with 'Install-Module posh-git' and restart cmder."
+    }
+    # Make sure we only run once by alawys returning true
+    return $true
+}
+
+function checkGit($Path) {  
+    if (Test-Path -Path (Join-Path $Path '.git') ) {
+      if($env:gitLoaded -eq 'false') {
+        $env:gitLoaded = Import-Git $gitLoaded
+      }
+      Write-VcsStatus
+      return
+    }
+    $SplitPath = split-path $path
+    if ($SplitPath) {
+        checkGit($SplitPath)
+    }
+}
+
+


### PR DESCRIPTION
* Fixes/Adds #2197, #1364, #447 - slow on large git repos.  Works for cmder, powershell, and bash shells.  See README.md for how to configure.

* Fix #2191 - profile.ps1: CheckGit does not export $gitLoaded