### PR TITLE
1.3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## [Unreleased]
 
-## [1.3.13](https://github.com/cmderdev/cmder/tree/v1.3.12) (2019-11-03)
+### Fixes
+
+* #2218 Cmder v1.3.13 init script fails. [#2218](https://github.com/cmderdev/cmder/issues/2218)
+* #2220 Git & env related error messages. [#2220](https://github.com/cmderdev/cmder/issues/2220)
+
+## [1.3.13](https://github.com/cmderdev/cmder/tree/v1.3.13) (2019-11-03)
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
 # Change Log
 
-## [Unreleased]
+## [1.3.14-pre](https://github.com/cmderdev/cmder) [Unreleased]
 
 ### Fixes
 
 * Pull Request: [#2222](https://github.com/cmderdev/cmder/pull/2222)
   * Cmder v1.3.13 init script fails. [#2218](https://github.com/cmderdev/cmder/issues/2218)
   * Git & env related error messages. [#2220](https://github.com/cmderdev/cmder/issues/2220)
+  * Latest addition of "--nolog" clink breaks cmd prompts. [#2166](https://github.com/cmderdev/cmder/issues/2166)
+
+### Changes
+
+* Update Git for Windows to 2.24.1.windows.2
+  * Pull Request: [#2237](https://github.com/cmderdev/cmder/pull/2237)
 
 ## [1.3.13](https://github.com/cmderdev/cmder/tree/v1.3.13) (2019-11-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### Fixes
 
-* Cmder v1.3.13 init script fails. [#2218](https://github.com/cmderdev/cmder/issues/2218)
-* Git & env related error messages. [#2220](https://github.com/cmderdev/cmder/issues/2220)
+* Pull Request: [#2222](https://github.com/cmderdev/cmder/pull/2222)
+  * Cmder v1.3.13 init script fails. [#2218](https://github.com/cmderdev/cmder/issues/2218)
+  * Git & env related error messages. [#2220](https://github.com/cmderdev/cmder/issues/2220)
 
 ## [1.3.13](https://github.com/cmderdev/cmder/tree/v1.3.13) (2019-11-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   * Cmder v1.3.13 init script fails. [#2218](https://github.com/cmderdev/cmder/issues/2218)
   * Git & env related error messages. [#2220](https://github.com/cmderdev/cmder/issues/2220)
   * Latest addition of "--nolog" clink breaks cmd prompts. [#2166](https://github.com/cmderdev/cmder/issues/2166)
+  * `/nix_tools 0` should prevent adding `%GIT_INSTALL_ROOT%\mingw64\bin` to PATH. [#2214](https://github.com/cmderdev/cmder/issues/2214)
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## [1.3.14-pre](https://github.com/cmderdev/cmder) [Unreleased]
+## 1.3.14-pre [Unreleased]
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Fixes
 
-* #2218 Cmder v1.3.13 init script fails. [#2218](https://github.com/cmderdev/cmder/issues/2218)
-* #2220 Git & env related error messages. [#2220](https://github.com/cmderdev/cmder/issues/2220)
+* Cmder v1.3.13 init script fails. [#2218](https://github.com/cmderdev/cmder/issues/2218)
+* Git & env related error messages. [#2220](https://github.com/cmderdev/cmder/issues/2220)
 
 ## [1.3.13](https://github.com/cmderdev/cmder/tree/v1.3.13) (2019-11-03)
 

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -219,13 +219,13 @@ if %nix_tools% equ 1 (
 )
 
 if exist "%GIT_INSTALL_ROOT%\cmd\git.exe" %lib_path% enhance_path "%GIT_INSTALL_ROOT%\cmd" %path_position%
-if exist "%GIT_INSTALL_ROOT%\mingw32" (
-    %lib_path% enhance_path "%GIT_INSTALL_ROOT%\mingw32\bin" %path_position%
-) else if exist "%GIT_INSTALL_ROOT%\mingw64" (
-    %lib_path% enhance_path "%GIT_INSTALL_ROOT%\mingw64\bin" %path_position%
-)
-
 if %nix_tools% geq 1 (
+    if exist "%GIT_INSTALL_ROOT%\mingw32" (
+        %lib_path% enhance_path "%GIT_INSTALL_ROOT%\mingw32\bin" %path_position%
+    ) else if exist "%GIT_INSTALL_ROOT%\mingw64" (
+        %lib_path% enhance_path "%GIT_INSTALL_ROOT%\mingw64\bin" %path_position%
+    )
+
     %lib_path% enhance_path "%GIT_INSTALL_ROOT%\usr\bin" %path_position%
 )
 

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -232,15 +232,17 @@ if not defined SVN_SSH set "SVN_SSH=%GIT_INSTALL_ROOT:\=\\%\\bin\\ssh.exe"
 
 :: Find locale.exe: From the git install root, from the path, using the git installed env, or fallback using the env from the path.
 if not defined git_locale if exist "%GIT_INSTALL_ROOT%\usr\bin\locale.exe" set git_locale="%GIT_INSTALL_ROOT%\usr\bin\locale.exe"
-if not defined git_locale for /F "delims=" %%F in ('where locale.exe 2^>nul') do (if not defined git_locale  set git_locale="%%F")
+if not defined git_locale for /F "tokens=* delims=" %%F in ('where locale.exe 2^>nul') do ( if not defined git_locale  set git_locale="%%F" )
 if not defined git_locale if exist "%GIT_INSTALL_ROOT%\usr\bin\env.exe" set git_locale="%GIT_INSTALL_ROOT%\usr\bin\env.exe" /usr/bin/locale
-if not defined git_locale set git_locale=env /usr/bin/locale
+if not defined git_locale for /F "tokens=* delims=" %%F in ('where env.exe 2^>nul') do ( if not defined git_locale  set git_locale="%%F" /usr/bin/locale )
 
-%lib_console% debug_output init.bat "Env Var - git_locale=%git_locale%"
-if not defined LANG (
-    for /F "delims=" %%F in ('%git_locale% -uU 2') do (
-        set "LANG=%%F"
-    )
+if defined git_locale (
+  %lib_console% debug_output init.bat "Env Var - git_locale=%git_locale%"
+  if not defined LANG (
+      for /F "delims=" %%F in ('%git_locale% -uU 2') do (
+          set "LANG=%%F"
+      )
+  )
 )
 
 %lib_console% debug_output init.bat "Env Var - GIT_INSTALL_ROOT=%GIT_INSTALL_ROOT%"

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -316,8 +316,14 @@ call "%user_aliases%"
 :: Basically we need to execute this post-install.bat because we are
 :: manually extracting the archive rather than executing the 7z sfx
 if exist "%GIT_INSTALL_ROOT%\post-install.bat" (
-    echo Running Git for Windows one time Post Install....
+    echo Running Git for Windows one time post install - %GIT_INSTALL_ROOT%\post-install.bat"....
     pushd "%GIT_INSTALL_ROOT%\"
+    copy post-install.bat post-install.cmder-bak.bat
+    if not exist "etc\post-install-cmder.bak" (
+      md etc\post-install-cmder.bak
+    )
+    xcopy etc\post-install\* etc\post-install-cmder.bak
+    copy post-install.bat post-install.cmder-bak.bat
     "%GIT_INSTALL_ROOT%\git-cmd.exe" --no-needs-console --no-cd --command=post-install.bat
     popd
 )


### PR DESCRIPTION
# Needs end user confirmation and testing

## 1.3.14-pre [Unreleased]

### Fixes

* Pull Request: [#2222](https://github.com/cmderdev/cmder/pull/2222)
  * Cmder v1.3.13 init script fails. [#2218](https://github.com/cmderdev/cmder/issues/2218)
  * Git & env related error messages. [#2220](https://github.com/cmderdev/cmder/issues/2220)
  * Latest addition of "--nolog" clink breaks cmd prompts. [#2166](https://github.com/cmderdev/cmder/issues/2166)
  * `/nix_tools 0` should prevent adding `%GIT_INSTALL_ROOT%\mingw64\bin` to PATH. [#2214](https://github.com/cmderdev/cmder/issues/2214)