### PR TITLE
Fixes #2247, fixes #2254

### DIFF
--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -188,6 +188,10 @@ for /F "delims=" %%F in ('where git.exe 2^>nul') do (
     call :compare_git_versions
 )
 
+if defined GIT_INSTALL_ROOT (
+    goto :FOUND_GIT
+)
+
 :: our last hope: our own git...
 :VENDORED_GIT
 if exist "%CMDER_ROOT%\vendor\git-for-windows" (
@@ -399,11 +403,9 @@ exit /b
         if %errorlevel% geq 0 if exist "%test_dir:~0,-4%\cmd\git.exe" (
             set "GIT_INSTALL_ROOT=%test_dir:~0,-4%"
             set test_dir=
-            goto :FOUND_GIT
         ) else if %errorlevel% geq 0 (
             set "GIT_INSTALL_ROOT=%test_dir%"
             set test_dir=
-            goto :FOUND_GIT
         ) else (
             call :verbose_output Found old %GIT_VERSION_USER% in "%test_dir%", but not using...
             set test_dir=


### PR DESCRIPTION
I believe the two referenced issues are due to the call to `:compare_git_versions` subroutine in init.bat.

```batchfile
:compare_git_versions
    if %errorlevel% geq 0 (
        :: compare the user git version against the vendored version
        %lib_git% compare_versions USER VENDORED

        :: use the user provided git if its version is greater than, or equal to the vendored git
        if %errorlevel% geq 0 if exist "%test_dir:~0,-4%\cmd\git.exe" (
            set "GIT_INSTALL_ROOT=%test_dir:~0,-4%"
            set test_dir=
            goto :FOUND_GIT
        ) else if %errorlevel% geq 0 (
            set "GIT_INSTALL_ROOT=%test_dir%"
            set test_dir=
            goto :FOUND_GIT
        ) else (
            call :verbose_output Found old %GIT_VERSION_USER% in "%test_dir%", but not using...
            set test_dir=
        )
    ) else (
        :: compare the user git version against the vendored version
        :: if the user provided git executable is not found
        if %errorlevel% equ -255 (
            call :verbose_output No git at "%git_executable%" found.
            set test_dir=
        )
    )
    exit /b
```

The problem is that inside the `:compare_git_versions` subroutine, if the user has non-vendored versions of git installed, the `goto :FOUND_GIT` line will move the program out of the subroutine without exiting, and the program will run until it reaches `exit /b` (line 373) at the end of the `:PATH_ENHANCE` subroutine. At that point it _technically_ exits the `:compare_git_versions` subroutine and returns to the line after the call (line 189). I believe it repeats this process for every version of git found in path, so users with a lengthy user_profile.cmd end up doubling or tripling the items added to path. In my case, this was causing "The input line is too long" error as well.