### PR TITLE
Clink path get broken if clink-completions content is created in a different order

### DIFF
--- a/vendor/clink.lua
+++ b/vendor/clink.lua
@@ -248,6 +248,8 @@ clink.prompt.register_filter(hg_prompt_filter, 50)
 clink.prompt.register_filter(git_prompt_filter, 50)
 
 local completions_dir = clink.get_env('CMDER_ROOT')..'/vendor/clink-completions/'
+-- Execute '.init.lua' first to ensure package.path is set properly
+dofile(completions_dir..".init.lua")
 for _,lua_module in ipairs(clink.find_files(completions_dir..'*.lua')) do
     -- Skip files that starts with _. This could be useful if some files should be ignored
     if not string.match(lua_module, '^_.*') then

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -173,7 +173,14 @@ if exist "%CMDER_ROOT%\config\user-profile.cmd" (
     echo :: use this file to run your own startup commands
     echo :: use  in front of the command to prevent printing the command
     echo.
+    echo :: uncomment this to have the ssh agent load when cmder starts
     echo :: call "%%GIT_INSTALL_ROOT%%/cmd/start-ssh-agent.cmd"
+    echo.
+    echo :: uncomment this next two lines to use pageant as the ssh authentication agent
+    echo :: SET SSH_AUTH_SOCK=/tmp/.ssh-pageant-auth-sock
+    echo :: call "%%GIT_INSTALL_ROOT%%/cmd/start-ssh-pageant.cmd"
+    echo.
+    echo :: you can add your plugins to the cmder path like so
     echo :: set "PATH=%%CMDER_ROOT%%\vendor\whatever;%%PATH%%"
     echo.
     ) > "%CMDER_ROOT%\config\user-profile.cmd"


### PR DESCRIPTION
In clink.lua line 434 we use clink.find_files() to call each lua script from clink-completions folder: 
```
local completions_dir = clink.get_env('CMDER_ROOT')..'/vendor/clink-completions/'
for _,lua_module in ipairs(clink.find_files(completions_dir..'*.lua')) do
```

The find_file function is implemented in the Clink dll (https://github.com/mridgers/clink/blob/0.4.9/clink/dll/lua.c#L215) and make use of readdir() to list files present. But readdir() doesn't ensure any order for file being returned (see http://man7.org/linux/man-pages/man3/readdir.3.html). It seems that on Windows the order returned depends on the file creation order.

This means currently the order of execution for scripts inside clink-completions is not enforced, but .init.lua must be executed first since it's setting the path for `require` calls made after.
If for some reason somebody had their clink-completion folder content created in a different order (like it happened for me) then when Clink is started an error is printed: `module '<NAME>' not found`.
This can be tested by deleting and recreating .init.lua inside clink-completion folder after installation.

To avoid this issue I think it would be safer to always call .init.lua first before looping through the content of clink-completion. This is the change proposed with this pull request.

Note that I followed the Contributing Guidelines (https://github.com/cmderdev/cmder/blob/master/CONTRIBUTING.md) but it seems that the development branch to use for pull request is quite outdated compared to master. Let me know if I should have done differently. 