### PR TITLE
Update git for windows to 2.26.2

### DIFF
--- a/vendor/sources.json
+++ b/vendor/sources.json
@@ -1,8 +1,8 @@
 [
     {
         "name": "git-for-windows",
-        "version": "v2.24.1.windows.2",
-        "url": "https://github.com/git-for-windows/git/releases/download/v2.24.1.windows.2/PortableGit-2.24.1.2-64-bit.7z.exe"
+        "version": "v2.26.2.windows.1",
+        "url": "https://github.com/git-for-windows/git/releases/download/v2.26.2.windows.1/PortableGit-2.26.2-64-bit.7z.exe"
     },
     {
         "name": "clink",


### PR DESCRIPTION
Release Note: https://github.com/git-for-windows/git/releases/tag/v2.26.2.windows.1