### PR TITLE
Fix and enhance enhance_path_recursive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 
 bin/*
 !bin/Readme.md
+opt/*
+!opt/Readme.md
 
 vendor/*/*
 !vendor/bin/*

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The Cmder's user interface is also designed to be more eye pleasing, and you can
 2. Extract the archive to a shared location.
 3. (optional) Place your own executable files and custom app folders into the `%cmder_root%\bin`. See: [opt/README.md](./bin/README)
    - This folder to be injected into your PATH by default.
-   - See `/max_depth [1-5]` in blow table to add subdirectories recursively.
+   - See `/max_depth [1-5]` in 'Command Line Arguments for `init.bat`' table to add subdirectories recursively.
 4. (optional) Place your own custom app folders into the `%cmder_root%\opt`. See: [opt/README.md](./opt/README)
    - This folder will NOT be injected into your PATH so you have total control of what gets added.
 5. Run `Cmder.exe` with `/C` command line argument. Example: `cmder.exe /C %userprofile%\cmder_config`
@@ -41,7 +41,7 @@ The Cmder's user interface is also designed to be more eye pleasing, and you can
 
   - (optional) Place your own executable files and custom app folders into `%userprofile%\cmder_config\bin`.
     - This folder to be injected into your PATH by default.
-    - See `/max_depth [1-5]` in blow table to add subdirectories recursively.
+    - See `/max_depth [1-5]` in 'Command Line Arguments for `init.bat`' table to add subdirectories recursively.
   - (optional) Place your own custom app folders into the `%user_profile%\cmder_config\opt`.
     - This folder will NOT be injected into your PATH so you have total control of what gets added.
 

--- a/README.md
+++ b/README.md
@@ -23,18 +23,28 @@ The Cmder's user interface is also designed to be more eye pleasing, and you can
 ### Shared Cmder install with Non-Portable Individual User Config
 1. Download the [latest release](https://github.com/cmderdev/cmder/releases/)
 2. Extract the archive to a shared location.
-3. (optional) Place your own executable files into the `%cmder_root%\bin` folder to be injected into your PATH.
-4. (optional) Create `%userprofile%\cmder_config\bin` folder to be injected into individual users PATH.  Default is to auto create this on first run.
-5. (optional) Place your own executable files into the `%userprofile%\cmder_config\bin` folder to be injected into your PATH.
-6. Run `Cmder.exe` with `/C` command line argument. Example: `cmder.exe /C %userprofile%\cmder_config`
+3. (optional) Place your own executable files and custom app folders into the `%cmder_root%\bin`. See: [opt/README.md](./bin/README)
+   - This folder to be injected into your PATH by default.
+   - See `/max_depth [1-5]` in blow table to add subdirectories recursively.
+4. (optional) Place your own custom app folders into the `%cmder_root%\opt`. See: [opt/README.md](./opt/README)
+   - This folder will NOT be injected into your PATH so you have total control of what gets added.
+5. Run `Cmder.exe` with `/C` command line argument. Example: `cmder.exe /C %userprofile%\cmder_config`
    * This will create the following directory structure if it is missing.
 
      ```
      c:\users\[username]\cmder_config
      ├───bin
-     └───config
-         └───profile.d
+     ├───config
+     │   └───profile.d
+     └───opt
      ```
+
+  - (optional) Place your own executable files and custom app folders into `%userprofile%\cmder_config\bin`.
+    - This folder to be injected into your PATH by default.
+    - See `/max_depth [1-5]` in blow table to add subdirectories recursively.
+  - (optional) Place your own custom app folders into the `%user_profile%\cmder_config\opt`.
+    - This folder will NOT be injected into your PATH so you have total control of what gets added.
+
 
 * Both the shared install and the individual user config locations can contain a full set of init and profile.d scripts enabling shared config with user overrides.  See below.
 

--- a/opt/Readme.md
+++ b/opt/Readme.md
@@ -1,0 +1,5 @@
+## Bin
+
+This folder is for optional user packages and will not be automatically injected into the PATH.
+
+Use `%lib_path% enhance_path "%cmder_root%\[path to folder]"` in `%cmder_root%\config\user_profile.cmd` or `%cmder_root%\config\profile.d\*.cmd` to add to the path.

--- a/vendor/bin/cexec.cmd
+++ b/vendor/bin/cexec.cmd
@@ -19,8 +19,8 @@ set "currenArgu=%~1"
 if /i "%currenArgu%" equ "/setPath" (
   :: set %flag_exists% shortcut
   endlocal
-  set "ccall=call %~dp0cexec.cmd"
-  set "cexec=%~dp0cexec.cmd"
+  set "ccall=call ^"%~dp0cexec.cmd^""
+  set "cexec=^"%~dp0cexec.cmd^""
 ) else if /i "%currenArgu%" == "/?" (
   goto :help
 ) else if /i "%currenArgu%" equ "/help" (

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -120,6 +120,8 @@ goto var_loop
 
 if defined CMDER_USER_CONFIG (
     %lib_console% debug_output init.bat "CMDER IS ALSO USING INDIVIDUAL USER CONFIG FROM '%CMDER_USER_CONFIG%'!"
+
+    if not exist "%CMDER_USER_CONFIG%\opt" md "%CMDER_USER_CONFIG%\opt"
 )
 
 :: Pick right version of clink
@@ -261,9 +263,9 @@ endlocal
 
 :PATH_ENHANCE
 %lib_path% enhance_path "%CMDER_ROOT%\vendor\bin"
-%lib_path% enhance_path_recursive "%CMDER_ROOT%\bin" %max_depth%
+%lib_path% enhance_path_recursive "%CMDER_ROOT%\bin" 0 %max_depth%
 if defined CMDER_USER_BIN (
-  %lib_path% enhance_path_recursive "%CMDER_USER_BIN%" %max_depth%
+  %lib_path% enhance_path_recursive "%CMDER_USER_BIN%" 0 %max_depth%
 )
 %lib_path% enhance_path "%CMDER_ROOT%" append
 

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -51,11 +51,11 @@ call "%cmder_root%\vendor\lib\lib_console"
 call "%cmder_root%\vendor\lib\lib_git"
 call "%cmder_root%\vendor\lib\lib_profile"
 
-if "%CMDER_CONFIGURED%" == "1" (
-  echo Cmder is already configured, skipping to user config!
-
-  goto USER_CONFIG_START
-)
+:: if "%CMDER_CONFIGURED%" == "1" (
+::   echo Cmder is already configured, skipping to user config!
+:: 
+::   goto USER_CONFIG_START
+:: )
 
 :var_loop
     if "%~1" == "" (

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -9,13 +9,22 @@ set CMDER_INIT_START=%time%
 :: !!! Use "%CMDER_ROOT%\config\user_profile.cmd" to add your own startup commands
 
 :: Use /v command line arg or set to > 0 for verbose output to aid in debugging.
-set verbose_output=0
-set debug_output=0
-set time_init=0
-set fast_init=0
-set max_depth=1
-:: Add *nix tools to end of path. 0 turns off *nix tools.
-set nix_tools=1
+if not defined verbose_output set verbose_output=0
+
+:: Use /d command line arg or set to 1 for debug output to aid in debugging.
+if not defined debug_output set debug_output=0
+
+:: Use /t command line arg or set to 1 to display init time.
+if not defined time_init set time_init=0
+
+:: Use /f command line arg to speed up init at the expense of some functionality.
+if not defined fast_init set fast_init=0
+
+:: Use /max_depth 1-5 to set max recurse depth for calls to `enhance_path_recursive`
+if not defined max_depth set max_depth=1
+
+:: Add *nix tools to end of path. 0 turns off *nix tools, 2 adds *nix tools to the front of thr path.
+if not defined nix_tools set nix_tools=1
 set "CMDER_USER_FLAGS= "
 
 :: Find root dir

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -172,6 +172,12 @@ if "%CMDER_CLINK%" == "1" (
   %lib_console% verbose_output "WARNING: Incompatible 'ComSpec/Shell' Detetected Skipping Clink Injection!"
 )
 
+if "%CMDER_CONFIGURED%" == "1" (
+  echo Cmder is already configured, skipping to user config!
+
+  goto USER_CONFIG_START
+)
+
 :: Prepare for git-for-windows
 
 :: I do not even know, copypasted from their .bat

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -51,12 +51,6 @@ call "%cmder_root%\vendor\lib\lib_console"
 call "%cmder_root%\vendor\lib\lib_git"
 call "%cmder_root%\vendor\lib\lib_profile"
 
-:: if "%CMDER_CONFIGURED%" == "1" (
-::   echo Cmder is already configured, skipping to user config!
-:: 
-::   goto USER_CONFIG_START
-:: )
-
 :var_loop
     if "%~1" == "" (
         goto :start
@@ -173,9 +167,9 @@ if "%CMDER_CLINK%" == "1" (
 )
 
 if "%CMDER_CONFIGURED%" == "1" (
-  echo Cmder is already configured, skipping to user config!
+  echo Cmder is already configured, skipping Cmder Init!
 
-  goto USER_CONFIG_START
+  goto CMDER_CONFIGURED
 )
 
 :: Prepare for git-for-windows
@@ -393,6 +387,8 @@ if "%CMDER_ALIASES%" == "1" if exist "%CMDER_ROOT%\bin\alias.bat" if exist "%CMD
 )
 
 set initialConfig=
+
+:CMDER_CONFIGURED
 set CMDER_CONFIGURED=1
 
 set CMDER_INIT_END=%time%

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -25,6 +25,7 @@ if not defined max_depth set max_depth=1
 
 :: Add *nix tools to end of path. 0 turns off *nix tools, 2 adds *nix tools to the front of thr path.
 if not defined nix_tools set nix_tools=1
+
 set "CMDER_USER_FLAGS= "
 
 :: Find root dir
@@ -49,6 +50,12 @@ call "%cmder_root%\vendor\lib\lib_path"
 call "%cmder_root%\vendor\lib\lib_console"
 call "%cmder_root%\vendor\lib\lib_git"
 call "%cmder_root%\vendor\lib\lib_profile"
+
+if "%CMDER_CONFIGURED%" == "1" (
+  echo Cmder is already configured, skipping to user config!
+
+  goto USER_CONFIG_START
+)
 
 :var_loop
     if "%~1" == "" (
@@ -272,6 +279,8 @@ endlocal
 
 :PATH_ENHANCE
 %lib_path% enhance_path "%CMDER_ROOT%\vendor\bin"
+
+:USER_CONFIG_START
 %lib_path% enhance_path_recursive "%CMDER_ROOT%\bin" 0 %max_depth%
 if defined CMDER_USER_BIN (
   %lib_path% enhance_path_recursive "%CMDER_USER_BIN%" 0 %max_depth%


### PR DESCRIPTION
# Reasons for these changes

I am using Cmder for the first time for a job where I am working from unfamiliar territory, a Windows VM.  It's an opportunity to use Cmder in many ways using other tools others users have and  I am embracing it fully.  I am making every effort to do things in a portable way  so I can simply zip the Cmder folder and move my env wherever I want with minimal manual reconfiguration.

The daily use of Cmder has made the changes in this PR seem very obvious to me.

## Fixes

* Fix `enhance_path_recursive`.  It was not adding directories properly.

## Adds

* `enhance_path_recursive` only enhances the path if a `[*.COM|*.EXE|*.BAT|*.CMD|*.PS1|*.VBS]` file is in the folder.
* Add `%cmder_root%/opt` and Add `%cmder_user_config%/opt` folders for optional package folders that are not added to the `PATH` so the user can control exactly what folders get added.  This might be necessary if using `init.bat /max_depth [1-5]`.

## Changes

* Update `README.md` 
* Allows setting the following globally on windows:
  _Note: This is useful for vscode integration where args cannot be passed via `settings.json`. See: #2299_
  - `%nix_tools%`
  - `%fast_init%`
  - `%debug_output%`
  - `%verbose_output%`
  - `%max_depth%`
* If `%CMDER_CONFIGURED% == 1` skip to Cmder User Config without running Cmder config.  Allows re-running `init.bat` inside a session to test user settings changes without starting a new shell or when using vscode integration and vscode is launched from a Cmder session.  See #2299