### PR TITLE
Added support for setting custom icons for Cmder window

### DIFF
--- a/launcher/CmderLauncher.sln
+++ b/launcher/CmderLauncher.sln
@@ -9,12 +9,18 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Win32 = Debug|Win32
 		Release|Win32 = Release|Win32
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{4A8485A5-B7DD-4C44-B7F6-3E2765DD0CD3}.Debug|Win32.ActiveCfg = Debug|Win32
 		{4A8485A5-B7DD-4C44-B7F6-3E2765DD0CD3}.Debug|Win32.Build.0 = Debug|Win32
 		{4A8485A5-B7DD-4C44-B7F6-3E2765DD0CD3}.Release|Win32.ActiveCfg = Release|Win32
 		{4A8485A5-B7DD-4C44-B7F6-3E2765DD0CD3}.Release|Win32.Build.0 = Release|Win32
+		{4A8485A5-B7DD-4C44-B7F6-3E2765DD0CD3}.Debug|x64.ActiveCfg = Debug|x64
+		{4A8485A5-B7DD-4C44-B7F6-3E2765DD0CD3}.Debug|x64.Build.0 = Debug|x64
+		{4A8485A5-B7DD-4C44-B7F6-3E2765DD0CD3}.Release|x64.ActiveCfg = Release|x64
+		{4A8485A5-B7DD-4C44-B7F6-3E2765DD0CD3}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/launcher/CmderLauncher.vcxproj
+++ b/launcher/CmderLauncher.vcxproj
@@ -9,6 +9,14 @@
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{4A8485A5-B7DD-4C44-B7F6-3E2765DD0CD3}</ProjectGuid>
@@ -30,6 +38,19 @@
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141_xp</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -39,12 +60,26 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
     <TargetName>Cmder</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <TargetName>Cmder</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <TargetName>Cmder</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
     <TargetName>Cmder</TargetName>
   </PropertyGroup>
@@ -69,6 +104,52 @@
     </ResourceCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MinSpace</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>false</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+    <Manifest>
+      <AdditionalManifestFiles>src/app.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
+    </Manifest>
+    <PostBuildEvent>
+      <Command>copy $(TargetPath) $(SolutionDir)..\$(TargetFileName)</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <Manifest>
+      <AdditionalManifestFiles>src/app.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
+    </Manifest>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_USING_V110_SDK71_;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <PrecompiledHeader>

--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -71,7 +71,7 @@ bool FileExists(const wchar_t * filePath)
 	return false;
 }
 
-void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstring taskName = L"", std::wstring cfgRoot = L"", bool use_user_cfg = true, std::wstring conemu_args = L"")
+void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstring taskName = L"", std::wstring iconPath = L"", std::wstring cfgRoot = L"", bool use_user_cfg = true, std::wstring conemu_args = L"")
 {
 #if USE_TASKBAR_API
 	wchar_t appId[MAX_PATH] = { 0 };
@@ -111,7 +111,15 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 
 	PathRemoveFileSpec(exeDir);
 
-	PathCombine(icoPath, exeDir, L"icons\\cmder.ico");
+	if (PathFileExists(iconPath.c_str()))
+	{
+		std::copy(iconPath.begin(), iconPath.end(), icoPath);
+		icoPath[iconPath.length()] = 0;
+	}
+	else
+	{
+		PathCombine(icoPath, exeDir, L"icons\\cmder.ico");
+	}
 
 	PathCombine(configDirPath, exeDir, L"config");
 
@@ -532,6 +540,7 @@ struct cmderOptions
 	std::wstring cmderCfgRoot = L"";
 	std::wstring cmderStart = L"";
 	std::wstring cmderTask = L"";
+	std::wstring cmderIcon = L"";
 	std::wstring cmderRegScope = L"USER";
 	std::wstring cmderConEmuArgs = L"";
 	bool cmderSingle = false;
@@ -591,6 +600,11 @@ cmderOptions GetOption()
 			else if (_wcsicmp(L"/task", szArgList[i]) == 0)
 			{
 				cmderOptions.cmderTask = szArgList[i + 1];
+				i++;
+			}
+			else if (_wcsicmp(L"/icon", szArgList[i]) == 0)
+			{
+				cmderOptions.cmderIcon = szArgList[i + 1];
 				i++;
 			}
 			else if (_wcsicmp(L"/single", szArgList[i]) == 0)
@@ -659,13 +673,13 @@ cmderOptions GetOption()
 				}
 				else
 				{
-					MessageBox(NULL, L"Unrecognized parameter.\n\nValid options:\n\n    /c [CMDER User Root Path]\n\n    /task [ConEmu Task Name]\n\n    [/start [Start in Path] | [Start in Path]]\n\n    /single\n\n    /m\n\n    /x [ConEmu extra arguments]\n\nor\n\n    /register [USER | ALL]\n\nor\n\n    /unregister [USER | ALL]\n", MB_TITLE, MB_OK);
+					MessageBox(NULL, L"Unrecognized parameter (no start case).\n\nValid options:\n\n    /c [CMDER User Root Path]\n\n    /task [ConEmu Task Name]\n\n    [/start [Start in Path] | [Start in Path]]\n\n    /icon [CMDER Icon Path]\n\n    /single\n\n    /m\n\n    /x [ConEmu extra arguments]\n\nor\n\n    /register [USER | ALL]\n\nor\n\n    /unregister [USER | ALL]\n", MB_TITLE, MB_OK);
 					cmderOptions.error = true;
 				}
 			}
 			else
 			{
-				MessageBox(NULL, L"Unrecognized parameter.\n\nValid options:\n\n    /c [CMDER User Root Path]\n\n    /task [ConEmu Task Name]\n\n    [/start [Start in Path] | [Start in Path]]\n\n    /single\n\n    /m\n\n    /x [ConEmu extra arguments]\n\nor\n\n    /register [USER | ALL]\n\nor\n\n    /unregister [USER | ALL]\n", MB_TITLE, MB_OK);
+				MessageBox(NULL, L"Unrecognized parameter (start case).\n\nValid options:\n\n    /c [CMDER User Root Path]\n\n    /task [ConEmu Task Name]\n\n    [/start [Start in Path] | [Start in Path]]\n\n    /icon [CMDER Icon Path]\n\n    /single\n\n    /m\n\n    /x [ConEmu extra arguments]\n\nor\n\n    /register [USER | ALL]\n\nor\n\n    /unregister [USER | ALL]\n", MB_TITLE, MB_OK);
 				cmderOptions.error = true;
 			}
 		}
@@ -707,7 +721,7 @@ int APIENTRY _tWinMain(_In_ HINSTANCE hInstance,
 	}
 	else
 	{
-		StartCmder(cmderOptions.cmderStart, cmderOptions.cmderSingle, cmderOptions.cmderTask, cmderOptions.cmderCfgRoot, cmderOptions.cmderUserCfg, cmderOptions.cmderConEmuArgs);
+		StartCmder(cmderOptions.cmderStart, cmderOptions.cmderSingle, cmderOptions.cmderTask, cmderOptions.cmderIcon, cmderOptions.cmderCfgRoot, cmderOptions.cmderUserCfg, cmderOptions.cmderConEmuArgs);
 	}
 
 	return 0;

--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -673,13 +673,13 @@ cmderOptions GetOption()
 				}
 				else
 				{
-					MessageBox(NULL, L"Unrecognized parameter (no start case).\n\nValid options:\n\n    /c [CMDER User Root Path]\n\n    /task [ConEmu Task Name]\n\n    [/start [Start in Path] | [Start in Path]]\n\n    /icon [CMDER Icon Path]\n\n    /single\n\n    /m\n\n    /x [ConEmu extra arguments]\n\nor\n\n    /register [USER | ALL]\n\nor\n\n    /unregister [USER | ALL]\n", MB_TITLE, MB_OK);
+					MessageBox(NULL, L"Unrecognized parameter.\n\nValid options:\n\n    /c [CMDER User Root Path]\n\n    /task [ConEmu Task Name]\n\n    /icon [CMDER Icon Path]\n\n    [/start [Start in Path] | [Start in Path]]\n\n    /single\n\n    /m\n\n    /x [ConEmu extra arguments]\n\nor\n\n    /register [USER | ALL]\n\nor\n\n    /unregister [USER | ALL]\n", MB_TITLE, MB_OK);
 					cmderOptions.error = true;
 				}
 			}
 			else
 			{
-				MessageBox(NULL, L"Unrecognized parameter (start case).\n\nValid options:\n\n    /c [CMDER User Root Path]\n\n    /task [ConEmu Task Name]\n\n    [/start [Start in Path] | [Start in Path]]\n\n    /icon [CMDER Icon Path]\n\n    /single\n\n    /m\n\n    /x [ConEmu extra arguments]\n\nor\n\n    /register [USER | ALL]\n\nor\n\n    /unregister [USER | ALL]\n", MB_TITLE, MB_OK);
+				MessageBox(NULL, L"Unrecognized parameter.\n\nValid options:\n\n    /c [CMDER User Root Path]\n\n    /task [ConEmu Task Name]\n\n    /icon [CMDER Icon Path]\n\n    [/start [Start in Path] | [Start in Path]]\n\n    /single\n\n    /m\n\n    /x [ConEmu extra arguments]\n\nor\n\n    /register [USER | ALL]\n\nor\n\n    /unregister [USER | ALL]\n", MB_TITLE, MB_OK);
 				cmderOptions.error = true;
 			}
 		}


### PR DESCRIPTION
# Summary
Cmder's launcher currently overrides ConEmu's custom icon feature and defaults to using `cmder.ico`.
As a daily user of Cmder that uses a lot of different tasks, it can be difficult to identify which window is running which task in the taskbar.

This PR solves this issue by adding the `/icon <path>` command line argument.  
Examples of how it looks with custom icons:  
* Using `cmder_red.ico` for `{cmd::Cmder as Admin}`:  
  * Window:
![Window](https://puu.sh/FZJQ1/eaffc0e9d0.png)  
  * Task Bar:
![Task Bar](https://puu.sh/FZJSR/26ca11ccc6.png)  
* Using `cmder_blue.ico` for `{PowerShell:PowerShell}` task:  
  * Window:
![Window](https://puu.sh/FZJQi/94ba1fbbbd.png)  
  * Task Bar
![Task Bar](https://puu.sh/FZJSs/8af2b77464.png)

## Adds
* Add `/icon <path>` command line argument for choosing a custom icon.
* Add Debug and Release build configurations for x64.
