### PR TITLE
quote time measures for timer.cmd

### DIFF
--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -394,6 +394,6 @@ set CMDER_CONFIGURED=1
 set CMDER_INIT_END=%time%
 
 if %time_init% gtr 0 (
-  "%cmder_root%\vendor\bin\timer.cmd" %CMDER_INIT_START% %CMDER_INIT_END%
+  "%cmder_root%\vendor\bin\timer.cmd" "%CMDER_INIT_START%" "%CMDER_INIT_END%"
 )
 exit /b


### PR DESCRIPTION
The startup time duration is calculated wrongly ( at least for me, on Windows 1909, with CmderMini 1.3.15.1010 ). I got something like "Elapsed Time: 80:36:1.00 (290161.00s total)" printed into the cmder consle window. It can be solved by quoting the time measures taken in `init.bat`. 

It seems that `time.cmd` fails in recognizing two arguments. In fact it did split the first time measure into two arguments and ignored the second time measure.
Example: 
from the two time measures _%CMDER_INIT_START%_ and _%CMDER_INIT_END%_
```
λ echo %CMDER_INIT_START% %CMDER_INIT_END%
12:53:44,34 12:53:54,04
```
the call to `timer.cmd` creates following output (i print variables **start** and **end** in `timer.cmd` right after they got assigned the arguments)

```
λ c:\prg\cmder\vendor\bin\timer.cmd %CMDER_INIT_START% %CMDER_INIT_END%
start: 12:53:44
end:   34
Elapsed Time: 21:6:16.00 (75976.00s total)
```

With the fix proposed here i get
```
λ c:\prg\cmder\vendor\bin\timer.cmd "%CMDER_INIT_START%" "%CMDER_INIT_END%"
start: 12:53:44,34
end:   12:53:54,04
Elapsed Time: 0:0:9.70 (9.70s total)
```
