### PR TITLE
Fix git version comparison

### DIFF
--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -231,7 +231,9 @@ goto :CONFIGURE_GIT
 :CONFIGURE_GIT
 %lib_console% debug_output "Using Git from '%GIT_INSTALL_ROOT%..."
 :: Add git to the path
-rem add the unix commands at the end to not shadow windows commands like more
+if exist "%GIT_INSTALL_ROOT%\cmd\git.exe" %lib_path% enhance_path "%GIT_INSTALL_ROOT%\cmd" ""
+
+:: Add the unix commands at the end to not shadow windows commands like more
 if %nix_tools% equ 1 (
     %lib_console% debug_output init.bat "Preferring Windows commands"
     set "path_position=append"
@@ -240,7 +242,6 @@ if %nix_tools% equ 1 (
     set "path_position="
 )
 
-if exist "%GIT_INSTALL_ROOT%\cmd\git.exe" %lib_path% enhance_path "%GIT_INSTALL_ROOT%\cmd" %path_position%
 if %nix_tools% geq 1 (
     if exist "%GIT_INSTALL_ROOT%\mingw32" (
         %lib_path% enhance_path "%GIT_INSTALL_ROOT%\mingw32\bin" %path_position%

--- a/vendor/lib/lib_git.cmd
+++ b/vendor/lib/lib_git.cmd
@@ -231,15 +231,15 @@ exit /b
 :::-------------------------------------------------------------------------------
 
 :compare_git_versions
-    if %errorlevel% geq 0 (
+    if ERRORLEVEL 0 (
         :: compare the user git version against the vendored version
         %lib_git% compare_versions USER VENDORED
 
         :: use the user provided git if its version is greater than, or equal to the vendored git
-        if %errorlevel% geq 0 if exist "%test_dir:~0,-4%\cmd\git.exe" (
+        if ERRORLEVEL 0 if exist "%test_dir:~0,-4%\cmd\git.exe" (
             set "GIT_INSTALL_ROOT=%test_dir:~0,-4%"
             set test_dir=
-        ) else if %errorlevel% geq 0 (
+        ) else if ERRORLEVEL 0 (
             set "GIT_INSTALL_ROOT=%test_dir%"
             set test_dir=
         ) else (
@@ -249,7 +249,7 @@ exit /b
     ) else (
         :: compare the user git version against the vendored version
         :: if the user provided git executable is not found
-        if %errorlevel% equ -255 (
+        IF ERRORLEVEL -255 IF NOT ERRORLEVEL -254 (
             call :verbose_output No git at "%git_executable%" found.
             set test_dir=
         )

--- a/vendor/lib/lib_git.cmd
+++ b/vendor/lib/lib_git.cmd
@@ -236,12 +236,14 @@ exit /b
         %lib_git% compare_versions USER VENDORED
 
         :: use the user provided git if its version is greater than, or equal to the vendored git
-        if ERRORLEVEL 0 if exist "%test_dir:~0,-4%\cmd\git.exe" (
-            set "GIT_INSTALL_ROOT=%test_dir:~0,-4%"
-            set test_dir=
-        ) else if ERRORLEVEL 0 (
-            set "GIT_INSTALL_ROOT=%test_dir%"
-            set test_dir=
+        if ERRORLEVEL 0 (
+            if exist "%test_dir:~0,-4%\cmd\git.exe" (
+                set "GIT_INSTALL_ROOT=%test_dir:~0,-4%"
+                set test_dir=
+            ) else (
+                set "GIT_INSTALL_ROOT=%test_dir%"
+                set test_dir=
+            )
         ) else (
             call :verbose_output Found old %GIT_VERSION_USER% in "%test_dir%", but not using...
             set test_dir=

--- a/vendor/lib/lib_git.cmd
+++ b/vendor/lib/lib_git.cmd
@@ -245,14 +245,14 @@ exit /b
                 set test_dir=
             )
         ) else (
-            call :verbose_output Found old %GIT_VERSION_USER% in "%test_dir%", but not using...
+            %lib_console% verbose_output "Found old %GIT_VERSION_USER% in %test_dir%, but not using..."
             set test_dir=
         )
     ) else (
         :: compare the user git version against the vendored version
         :: if the user provided git executable is not found
         IF ERRORLEVEL -255 IF NOT ERRORLEVEL -254 (
-            call :verbose_output No git at "%git_executable%" found.
+            %lib_console% verbose_output "No git at "%git_executable%" found."
             set test_dir=
         )
     )


### PR DESCRIPTION
The most recent version of cmder didn't use the vendored git even if it's more current than an installed version.
This PR fixes several issues that prevented the git version comparison from correctly providing the most current git version.