### PR TITLE
Improve init speed

### DIFF
--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -67,7 +67,7 @@ call "%cmder_root%\vendor\lib\lib_profile"
             set "max_depth=%~2"
             shift
         ) else (
-            %lib_console% show_error "'/max_depth' requires a number between 1 and 5!"
+            %print_error% "'/max_depth' requires a number between 1 and 5!"
             exit /b
         )
     ) else if /i "%1" == "/c" (
@@ -88,7 +88,7 @@ call "%cmder_root%\vendor\lib\lib_profile"
             set "GIT_INSTALL_ROOT=%~2"
             shift
         ) else (
-            %lib_console% show_error "The Git install root folder "%~2", you specified does not exist!"
+            %print_error% "The Git install root folder "%~2", you specified does not exist!"
             exit /b
         )
     ) else if /i "%1"=="/nix_tools" (
@@ -110,7 +110,7 @@ call "%cmder_root%\vendor\lib\lib_profile"
             set "HOME=%~2"
             shift
         ) else (
-            %lib_console% show_error The home folder "%2", you specified does not exist!
+            %print_error% The home folder "%2", you specified does not exist!
             exit /b
         )
     ) else if /i "%1" == "/svn_ssh" (
@@ -125,11 +125,11 @@ goto var_loop
 :start
 :: Sets CMDER_SHELL, CMDER_CLINK, CMDER_ALIASES
 %lib_base% cmder_shell
-%lib_console% debug_output init.bat "Env Var - CMDER_ROOT=%CMDER_ROOT%"
-%lib_console% debug_output init.bat "Env Var - debug_output=%debug_output%"
+%print_debug% init.bat "Env Var - CMDER_ROOT=%CMDER_ROOT%"
+%print_debug% init.bat "Env Var - debug_output=%debug_output%"
 
 if defined CMDER_USER_CONFIG (
-    %lib_console% debug_output init.bat "CMDER IS ALSO USING INDIVIDUAL USER CONFIG FROM '%CMDER_USER_CONFIG%'!"
+    %print_debug% init.bat "CMDER IS ALSO USING INDIVIDUAL USER CONFIG FROM '%CMDER_USER_CONFIG%'!"
 
     if not exist "%CMDER_USER_CONFIG%\opt" md "%CMDER_USER_CONFIG%\opt"
 )
@@ -144,7 +144,7 @@ if "%PROCESSOR_ARCHITECTURE%"=="x86" (
 )
 
 if "%CMDER_CLINK%" == "1" (
-  %lib_console% verbose_output "Injecting Clink!"
+  %print_verbose% "Injecting Clink!"
 
   :: Run clink
   if defined CMDER_USER_CONFIG (
@@ -163,15 +163,15 @@ if "%CMDER_CLINK%" == "1" (
     "%CMDER_ROOT%\vendor\clink\clink_%clink_architecture%.exe" inject --quiet --profile "%CMDER_ROOT%\config" --scripts "%CMDER_ROOT%\vendor"
   )
 ) else (
-  %lib_console% verbose_output "WARNING: Incompatible 'ComSpec/Shell' Detetected Skipping Clink Injection!"
+  %print_verbose% "WARNING: Incompatible 'ComSpec/Shell' Detetected Skipping Clink Injection!"
 )
 
 if "%CMDER_CONFIGURED%" GTR "1" (
-  %lib_console% verbose_output "Cmder is already configured, skipping Cmder Init!"
+  %print_verbose% "Cmder is already configured, skipping Cmder Init!"
 
   goto USER_ALIASES
 ) else if "%CMDER_CONFIGURED%" == "1" (
-  %lib_console% verbose_output "Cmder is already configured, skipping to Cmder User Init!"
+  %print_verbose% "Cmder is already configured, skipping to Cmder User Init!"
 
   goto USER_CONFIG_START
 )
@@ -191,12 +191,12 @@ if defined GIT_INSTALL_ROOT (
     if exist "%GIT_INSTALL_ROOT%\cmd\git.exe" goto :SPECIFIED_GIT
 ) else if "%fast_init%" == "1" (
     if exist "%CMDER_ROOT%\vendor\git-for-windows\cmd\git.exe" (
-      %lib_console% debug_output "Skipping Git Auto-Detect!"
+      %print_debug% "Skipping Git Auto-Detect!"
       goto :VENDORED_GIT
     )
 )
 
-%lib_console% debug_output init.bat "Looking for Git install root..."
+%print_debug% init.bat "Looking for Git install root..."
 
 :: get the version information for vendored git binary
 %lib_git% read_version VENDORED "%CMDER_ROOT%\vendor\git-for-windows\cmd"
@@ -218,31 +218,31 @@ for /F "delims=" %%F in ('where git.exe 2^>nul') do (
 :VENDORED_GIT
 if exist "%CMDER_ROOT%\vendor\git-for-windows" (
     set "GIT_INSTALL_ROOT=%CMDER_ROOT%\vendor\git-for-windows"
-    %lib_console% debug_output "Using vendored Git '%GIT_VERSION_VENDORED%'..."
+    %print_debug% "Using vendored Git '%GIT_VERSION_VENDORED%'..."
     goto :CONFIGURE_GIT
 ) else (
     goto :NO_GIT
 )
 
 :SPECIFIED_GIT
-%lib_console% debug_output "Using /GIT_INSTALL_ROOT..."
+%print_debug% "Using /GIT_INSTALL_ROOT..."
 goto :CONFIGURE_GIT
 
 :FOUND_GIT
-%lib_console% debug_output "Using found Git '%GIT_VERSION_USER%' from '%GIT_INSTALL_ROOT%..."
+%print_debug% "Using found Git '%GIT_VERSION_USER%' from '%GIT_INSTALL_ROOT%..."
 goto :CONFIGURE_GIT
 
 :CONFIGURE_GIT
-%lib_console% debug_output "Using Git from '%GIT_INSTALL_ROOT%..."
+%print_debug% "Using Git from '%GIT_INSTALL_ROOT%..."
 :: Add git to the path
 if exist "%GIT_INSTALL_ROOT%\cmd\git.exe" %lib_path% enhance_path "%GIT_INSTALL_ROOT%\cmd" ""
 
 :: Add the unix commands at the end to not shadow windows commands like more
 if %nix_tools% equ 1 (
-    %lib_console% verbose_output "Preferring Windows commands"
+    %print_verbose% "Preferring Windows commands"
     set "path_position=append"
 ) else (
-    %lib_console% verbose_output "Preferring *nix commands"
+    %print_verbose% "Preferring *nix commands"
     set "path_position="
 )
 
@@ -268,7 +268,7 @@ if not defined git_locale for /F "tokens=* delims=" %%F in ('where env.exe 2^>nu
 setlocal enabledelayedexpansion
 if defined git_locale (
 
-  REM !lib_console! debug_output init.bat "Env Var - git_locale=!git_locale!"
+  REM !print_debug! init.bat "Env Var - git_locale=!git_locale!"
   if not defined LANG (
       for /F "delims=" %%F in ('!git_locale! -uU 2') do (
           set "LANG=%%F"
@@ -277,8 +277,8 @@ if defined git_locale (
 )
 endlocal && set LANG=%LANG%
 
-%lib_console% debug_output init.bat "Env Var - GIT_INSTALL_ROOT=%GIT_INSTALL_ROOT%"
-%lib_console% debug_output init.bat "Found Git in: '%GIT_INSTALL_ROOT%'"
+%print_debug% init.bat "Env Var - GIT_INSTALL_ROOT=%GIT_INSTALL_ROOT%"
+%print_debug% init.bat "Found Git in: '%GIT_INSTALL_ROOT%'"
 goto :PATH_ENHANCE
 
 :NO_GIT
@@ -361,12 +361,12 @@ if exist "%GIT_INSTALL_ROOT%\post-install.bat" (
 
 :: Set home path
 if not defined HOME set "HOME=%USERPROFILE%"
-%lib_console% debug_output init.bat "Env Var - HOME=%HOME%"
+%print_debug% init.bat "Env Var - HOME=%HOME%"
 
 set "initialConfig=%CMDER_ROOT%\config\user_profile.cmd"
 if exist "%CMDER_ROOT%\config\user_profile.cmd" (
     REM Create this file and place your own command in there
-    %lib_console% debug_output init.bat "Calling - %CMDER_ROOT%\config\user_profile.cmd"
+    %print_debug% init.bat "Calling - %CMDER_ROOT%\config\user_profile.cmd"
     call "%CMDER_ROOT%\config\user_profile.cmd"
 )
 
@@ -374,7 +374,7 @@ if defined CMDER_USER_CONFIG (
   set "initialConfig=%CMDER_USER_CONFIG%\user_profile.cmd"
   if exist "%CMDER_USER_CONFIG%\user_profile.cmd" (
       REM Create this file and place your own command in there
-      %lib_console% debug_output init.bat "Calling - %CMDER_USER_CONFIG%\user_profile.cmd"
+      %print_debug% init.bat "Calling - %CMDER_USER_CONFIG%\user_profile.cmd"
       call "%CMDER_USER_CONFIG%\user_profile.cmd"
   )
 )

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -268,7 +268,7 @@ if not defined git_locale for /F "tokens=* delims=" %%F in ('where env.exe 2^>nu
 setlocal enabledelayedexpansion
 if defined git_locale (
 
-  REM !print_debug! init.bat "Env Var - git_locale=!git_locale!"
+  REM %print_debug% init.bat "Env Var - git_locale=!git_locale!"
   if not defined LANG (
       for /F "delims=" %%F in ('!git_locale! -uU 2') do (
           set "LANG=%%F"

--- a/vendor/lib/lib_console.cmd
+++ b/vendor/lib/lib_console.cmd
@@ -3,6 +3,11 @@
 call "%~dp0lib_base.cmd"
 set lib_console=call "%~dp0lib_console.cmd"
 
+:: Much faster than using "%lib_console% debug_output ..." etc.
+set print_debug=if %debug_output% gtr 0 %lib_console% debug_output %*
+set print_verbose=if %verbose_output% gtr 0 %lib_console% verbose_output %*
+set print_error=%lib_console% show_error %*
+
 if "%fast_init%" == "1" exit /b
 
 if "%~1" == "/h" (

--- a/vendor/lib/lib_console.cmd
+++ b/vendor/lib/lib_console.cmd
@@ -4,9 +4,9 @@ call "%~dp0lib_base.cmd"
 set lib_console=call "%~dp0lib_console.cmd"
 
 :: Much faster than using "%lib_console% debug_output ..." etc.
-set print_debug=if %debug_output% gtr 0 %lib_console% debug_output %*
-set print_verbose=if %verbose_output% gtr 0 %lib_console% verbose_output %*
-set print_error=%lib_console% show_error %*
+set print_debug=if %debug_output% gtr 0 %lib_console% debug_output
+set print_verbose=if %verbose_output% gtr 0 %lib_console% verbose_output
+set print_error=%lib_console% show_error
 
 if "%fast_init%" == "1" exit /b
 

--- a/vendor/lib/lib_git.cmd
+++ b/vendor/lib/lib_git.cmd
@@ -244,13 +244,13 @@ exit /b
                 set "GIT_INSTALL_ROOT=!test_dir!"
             )
         ) else (
-            !print_verbose! "Found old !GIT_VERSION_USER! in !test_dir!, but not using..."
+            %print_verbose% "Found old !GIT_VERSION_USER! in !test_dir!, but not using..."
         )
     ) else (
         :: compare the user git version against the vendored version
         :: if the user provided git executable is not found
         IF ERRORLEVEL -255 IF NOT ERRORLEVEL -254 (
-            !print_verbose! "No git at "!git_executable!" found."
+            %print_verbose% "No git at "!git_executable!" found."
             set test_dir=
         )
     )

--- a/vendor/lib/lib_git.cmd
+++ b/vendor/lib/lib_git.cmd
@@ -39,11 +39,11 @@ exit /b
 
     :: set the executable path
     set "git_executable=%~2\git.exe"
-    %lib_console% debug_output :read_version "Env Var - git_executable=%git_executable%"
+    %print_debug% :read_version "Env Var - git_executable=%git_executable%"
 
     :: check if the executable actually exists
     if not exist "%git_executable%" (
-        %lib_console% debug_output :read_version "%git_executable% does not exist."
+        %print_debug% :read_version "%git_executable% does not exist."
         exit /b -255
     )
 
@@ -60,7 +60,7 @@ exit /b
             exit /b
         )
     )
-    endlocal & set "GIT_VERSION_%~1=%GIT_VERSION%" & %lib_console% debug_output :read_version "Env Var - GIT_VERSION_%~1=%GIT_VERSION%"
+    endlocal & set "GIT_VERSION_%~1=%GIT_VERSION%" & %print_debug% :read_version "Env Var - GIT_VERSION_%~1=%GIT_VERSION%"
 
     exit /b
 
@@ -90,7 +90,7 @@ exit /b
 :::-------------------------------------------------------------------------------
 
     :: process a `x.x.x.xxxx.x` formatted string
-    %lib_console% debug_output :parse_version "ARGV[1]=%~1, ARGV[2]=%~2"
+    %print_debug% :parse_version "ARGV[1]=%~1, ARGV[2]=%~2"
 
     setlocal enabledelayedexpansion
     for /F "tokens=1-3* delims=.,-" %%A in ("%2") do (
@@ -130,16 +130,16 @@ exit /b
 :::-------------------------------------------------------------------------------
 
     :: now parse the version information into the corresponding variables
-    %lib_console% debug_output :validate_version "ARGV[1]=%~1, ARGV[2]=%~2"
+    %print_debug% :validate_version "ARGV[1]=%~1, ARGV[2]=%~2"
 
     call :parse_version %~1 %~2
 
     :: ... and maybe display it, for debugging purposes.
-    REM %lib_console% debug_output :validate_version "Found Git Version for %~1: !%~1_MAJOR!.!%~1_MINOR!.!%~1_PATCH!.!%~1_BUILD!"
+    REM %print_debug% :validate_version "Found Git Version for %~1: !%~1_MAJOR!.!%~1_MINOR!.!%~1_PATCH!.!%~1_BUILD!"
     if "%~1" == "VENDORED" (
-      %lib_console% debug_output :validate_version "Found Git Version for %~1: %VENDORED_MAJOR%.%VENDORED_MINOR%.%VENDORED_PATCH%.%VENDORED_BUILD%"
+      %print_debug% :validate_version "Found Git Version for %~1: %VENDORED_MAJOR%.%VENDORED_MINOR%.%VENDORED_PATCH%.%VENDORED_BUILD%"
     ) else (
-      %lib_console% debug_output :validate_version "Found Git Version for %~1: %USER_MAJOR%.%USER_MINOR%.%USER_PATCH%.%USER_BUILD%"
+      %print_debug% :validate_version "Found Git Version for %~1: %USER_MAJOR%.%USER_MINOR%.%USER_PATCH%.%USER_BUILD%"
     )
     exit /b
 
@@ -164,9 +164,9 @@ exit /b
     :: checks all major, minor, patch and build variables for the given arguments.
     :: whichever binary that has the most recent version will be used based on the return code.
 
-    %lib_console% debug_output Comparing:
-    %lib_console% debug_output %~1: %USER_MAJOR%.%USER_MINOR%.%USER_PATCH%.%USER_BUILD%
-    %lib_console% debug_output %~2: %VENDORED_MAJOR%.%VENDORED_MINOR%.%VENDORED_PATCH%.%VENDORED_BUILD%
+    %print_debug% Comparing:
+    %print_debug% %~1: %USER_MAJOR%.%USER_MINOR%.%USER_PATCH%.%USER_BUILD%
+    %print_debug% %~2: %VENDORED_MAJOR%.%VENDORED_MINOR%.%VENDORED_PATCH%.%VENDORED_BUILD%
 
     setlocal enabledelayedexpansion
     if !%~1_MAJOR! GTR !%~2_MAJOR! (endlocal & exit /b  1)
@@ -244,13 +244,13 @@ exit /b
                 set "GIT_INSTALL_ROOT=!test_dir!"
             )
         ) else (
-            !lib_console! verbose_output "Found old !GIT_VERSION_USER! in !test_dir!, but not using..."
+            !print_verbose! "Found old !GIT_VERSION_USER! in !test_dir!, but not using..."
         )
     ) else (
         :: compare the user git version against the vendored version
         :: if the user provided git executable is not found
         IF ERRORLEVEL -255 IF NOT ERRORLEVEL -254 (
-            !lib_console! verbose_output "No git at "!git_executable!" found."
+            !print_verbose! "No git at "!git_executable!" found."
             set test_dir=
         )
     )

--- a/vendor/lib/lib_path.cmd
+++ b/vendor/lib/lib_path.cmd
@@ -81,20 +81,20 @@ exit /b
       echo "!path!"|!WINDIR!\System32\findstr >nul /I /R /C:";!find_query!;"
       call :set_found
     )
-    !print_debug!  :enhance_path "Env Var INSIDE PATH !find_query! - found=!found!"
+    %print_debug%  :enhance_path "Env Var INSIDE PATH !find_query! - found=!found!"
 
     if /i "!position!" == "append" (
       if "!found!" == "0" (
         echo "!path!"|!WINDIR!\System32\findstr >nul /I /R /C:";!find_query!\"$"
         call :set_found
       )
-      !print_debug!  :enhance_path "Env Var END PATH !find_query! - found=!found!"
+      %print_debug%  :enhance_path "Env Var END PATH !find_query! - found=!found!"
     ) else (
       if "!found!" == "0" (
         echo "!path!"|!WINDIR!\System32\findstr >nul /I /R /C:"^\"!find_query!;"
         call :set_found
       )
-      !print_debug!  :enhance_path "Env Var BEGIN PATH !find_query! - found=!found!"
+      %print_debug%  :enhance_path "Env Var BEGIN PATH !find_query! - found=!found!"
     )
     endlocal & set found=%found%
 

--- a/vendor/lib/lib_path.cmd
+++ b/vendor/lib/lib_path.cmd
@@ -42,7 +42,7 @@ exit /b
     if "%~1" neq "" (
         set "add_path=%~1"
     ) else (
-        %lib_console% show_error "You must specify a directory to add to the path!"
+        %print_error% "You must specify a directory to add to the path!"
         exit 1
     )
 
@@ -81,29 +81,29 @@ exit /b
       echo "!path!"|!WINDIR!\System32\findstr >nul /I /R /C:";!find_query!;"
       call :set_found
     )
-    !lib_console! debug_output  :enhance_path "Env Var INSIDE PATH !find_query! - found=!found!"
+    !print_debug!  :enhance_path "Env Var INSIDE PATH !find_query! - found=!found!"
 
     if /i "!position!" == "append" (
       if "!found!" == "0" (
         echo "!path!"|!WINDIR!\System32\findstr >nul /I /R /C:";!find_query!\"$"
         call :set_found
       )
-      !lib_console! debug_output  :enhance_path "Env Var END PATH !find_query! - found=!found!"
+      !print_debug!  :enhance_path "Env Var END PATH !find_query! - found=!found!"
     ) else (
       if "!found!" == "0" (
         echo "!path!"|!WINDIR!\System32\findstr >nul /I /R /C:"^\"!find_query!;"
         call :set_found
       )
-      !lib_console! debug_output  :enhance_path "Env Var BEGIN PATH !find_query! - found=!found!"
+      !print_debug!  :enhance_path "Env Var BEGIN PATH !find_query! - found=!found!"
     )
     endlocal & set found=%found%
 
     if "%found%" == "0" (
         if /i "%position%" == "append" (
-            %lib_console% debug_output :enhance_path "Appending '%add_to_path%'"
+            %print_debug% :enhance_path "Appending '%add_to_path%'"
             set "PATH=%PATH%;%add_to_path%"
         ) else (
-            %lib_console% debug_output :enhance_path "Prepending '%add_to_path%'"
+            %print_debug% :enhance_path "Prepending '%add_to_path%'"
             set "PATH=%add_to_path%;%PATH%"
         )
 
@@ -113,8 +113,8 @@ exit /b
     :end_enhance_path
     set "PATH=%PATH:;;=;%"
     if NOT "%OLD_PATH%" == "%PATH%" (
-      %lib_console% debug_output  :enhance_path "END Env Var - PATH=%path%"
-      %lib_console% debug_output  :enhance_path "Env Var %find_query% - found=%found%"
+      %print_debug%  :enhance_path "END Env Var - PATH=%path%"
+      %print_debug%  :enhance_path "Env Var %find_query% - found=%found%"
     )
     set "position="
     exit /b
@@ -156,7 +156,7 @@ exit /b
     if "%~1" neq "" (
         set "add_path=%~1"
     ) else (
-        %lib_console% show_error "You must specify a directory to add to the path!"
+        %print_error% "You must specify a directory to add to the path!"
         exit 1
     )
 
@@ -188,14 +188,14 @@ exit /b
       exit /b
     )
 
-    %lib_console% debug_output  :enhance_path_recursive "Env Var - add_path=%add_to_path%"
-    %lib_console% debug_output  :enhance_path_recursive "Env Var - position=%position%"
-    %lib_console% debug_output  :enhance_path_recursive "Env Var - depth=%depth%"
-    %lib_console% debug_output  :enhance_path_recursive "Env Var - max_depth=%max_depth%"
+    %print_debug%  :enhance_path_recursive "Env Var - add_path=%add_to_path%"
+    %print_debug%  :enhance_path_recursive "Env Var - position=%position%"
+    %print_debug%  :enhance_path_recursive "Env Var - depth=%depth%"
+    %print_debug%  :enhance_path_recursive "Env Var - max_depth=%max_depth%"
 
     if %max_depth% gtr %depth% (
         if "%add_to_path%" neq "" (
-            %lib_console% debug_output :enhance_path_recursive "Adding parent directory - '%add_to_path%'"
+            %print_debug% :enhance_path_recursive "Adding parent directory - '%add_to_path%'"
             call :enhance_path "%add_to_path%" %position%
         )
         call :set_depth
@@ -216,10 +216,10 @@ exit /b
     )
 
     for /d %%i in ("%add_path%\*") do (
-        %lib_console% debug_output  :enhance_path_recursive "Env Var BEFORE - depth=%depth%"
-        %lib_console% debug_output :enhance_path_recursive "Found Subdirectory - '%%~fi'"
+        %print_debug%  :enhance_path_recursive "Env Var BEFORE - depth=%depth%"
+        %print_debug% :enhance_path_recursive "Found Subdirectory - '%%~fi'"
         call :enhance_path_recursive "%%~fi" %depth% %max_depth% %position%
-        %lib_console% debug_output  :enhance_path_recursive "Env Var AFTER- depth=%depth%"
+        %print_debug%  :enhance_path_recursive "Env Var AFTER- depth=%depth%"
     )
     exit /b
 

--- a/vendor/lib/lib_profile.cmd
+++ b/vendor/lib/lib_profile.cmd
@@ -38,7 +38,7 @@ exit /b
 
   pushd "%~1"
   for /f "usebackq" %%x in ( `dir /b *.bat *.cmd 2^>nul` ) do (
-    %lib_console% verbose_output "Calling '%~1\%%x'..."
+    %print_verbose% "Calling '%~1\%%x'..."
     call "%~1\%%x"
   )
   popd


### PR DESCRIPTION
Hello,

The init scripts (`init.bat` and the files in `vendor/lib`) are full of calls to `lib_console` for debug/verbose logging. Unfortunately these calls have a cost which adds up to quite a lot. The reason is that doing e.g. `%lib_console% debug_output ....` invokes `call`, which is relatively slow. This cost is paid even if debug/verbose logging is turned off, which of course it is most of the time.

I have replaced such lines with `%print_debug%`/`%print_verbose%` instead, which first check that the relevant flag is set. I have added `%print_error%` for consistency, though this doesn't give any performance improvement. The original way to print, `%lib_console% debug_output ...` still works in case it's used somewhere else.

On my machine, without this change, the latest version of cmder_mini takes 1.41 sec on average to init (measured with time_init flag). With the change it takes 1.02 sec, so almost a 30% improvement.