### PR TITLE
Upgrade to latest version of ConEmu

### DIFF
--- a/vendor/sources.json
+++ b/vendor/sources.json
@@ -11,8 +11,8 @@
     },
     {
         "name": "conemu-maximus5",
-        "version": "191012",
-        "url": "https://github.com/Maximus5/ConEmu/releases/download/v19.10.12/ConEmuPack.191012.7z"
+        "version": "201124",
+        "url": "https://github.com/Maximus5/ConEmu/releases/download/v20.11.24/ConEmuPack.201124.7z"
     },
     {
         "name": "clink-completions",


### PR DESCRIPTION
Fixes some important issues, specifically pertaining to users using their own versions of Git and vim, for example, which ConEmu fixed in its October release.