### PR TITLE
Fix: Incomplete operation when closing bash.exe

### DIFF
--- a/vendor/ConEmu.xml.default
+++ b/vendor/ConEmu.xml.default
@@ -549,14 +549,14 @@
 					<value name="GuiArgs" type="string" data=" /icon &quot;%CMDER_ROOT%\icons\cmder.ico&quot;"/>
 					<value name="Active" type="long" data="0"/>
 					<value name="Count" type="long" data="1"/>
-					<value name="Cmd1" type="string" data="*cmd /c &quot;&quot;%ConEmuDir%\..\git-for-windows\bin\bash&quot; --login -i&quot;"/>
+					<value name="Cmd1" type="string" data="*%ConEmuDir%\..\git-for-windows\usr\bin\bash.exe --login -i"/>
 				</key>
 				<key name="Task8" modified="2018-02-22 06:05:13" build="171109">
 					<value name="Name" type="string" data="{bash::bash}"/>
 					<value name="Flags" type="dword" data="00000000"/>
 					<value name="Hotkey" type="dword" data="00000000"/>
 					<value name="GuiArgs" type="string" data=" /icon &quot;%CMDER_ROOT%\icons\cmder.ico&quot;"/>
-					<value name="Cmd1" type="string" data="cmd /c &quot;&quot;%ConEmuDir%\..\git-for-windows\bin\bash&quot; --login -i&quot;"/>
+					<value name="Cmd1" type="string" data="%ConEmuDir%\..\git-for-windows\usr\bin\bash.exe --login -i"/>
 					<value name="Active" type="long" data="0"/>
 					<value name="Count" type="long" data="1"/>
 				</key>

--- a/vendor/ConEmu.xml.default
+++ b/vendor/ConEmu.xml.default
@@ -549,14 +549,14 @@
 					<value name="GuiArgs" type="string" data=" /icon &quot;%CMDER_ROOT%\icons\cmder.ico&quot;"/>
 					<value name="Active" type="long" data="0"/>
 					<value name="Count" type="long" data="1"/>
-					<value name="Cmd1" type="string" data="*%ConEmuDir%\..\git-for-windows\usr\bin\bash.exe --login -i"/>
+					<value name="Cmd1" type="string" data="*"%ConEmuDir%\..\git-for-windows\usr\bin\bash.exe" --login -i"/>
 				</key>
 				<key name="Task8" modified="2018-02-22 06:05:13" build="171109">
 					<value name="Name" type="string" data="{bash::bash}"/>
 					<value name="Flags" type="dword" data="00000000"/>
 					<value name="Hotkey" type="dword" data="00000000"/>
 					<value name="GuiArgs" type="string" data=" /icon &quot;%CMDER_ROOT%\icons\cmder.ico&quot;"/>
-					<value name="Cmd1" type="string" data="%ConEmuDir%\..\git-for-windows\usr\bin\bash.exe --login -i"/>
+					<value name="Cmd1" type="string" data=""%ConEmuDir%\..\git-for-windows\usr\bin\bash.exe" --login -i"/>
 					<value name="Active" type="long" data="0"/>
 					<value name="Count" type="long" data="1"/>
 				</key>

--- a/vendor/ConEmu.xml.default
+++ b/vendor/ConEmu.xml.default
@@ -549,14 +549,14 @@
 					<value name="GuiArgs" type="string" data=" /icon &quot;%CMDER_ROOT%\icons\cmder.ico&quot;"/>
 					<value name="Active" type="long" data="0"/>
 					<value name="Count" type="long" data="1"/>
-					<value name="Cmd1" type="string" data="*"%ConEmuDir%\..\git-for-windows\usr\bin\bash.exe" --login -i"/>
+					<value name="Cmd1" type="string" data="*&quot;%ConEmuDir%\..\git-for-windows\usr\bin\bash.exe&quot; --login -i"/>
 				</key>
 				<key name="Task8" modified="2018-02-22 06:05:13" build="171109">
 					<value name="Name" type="string" data="{bash::bash}"/>
 					<value name="Flags" type="dword" data="00000000"/>
 					<value name="Hotkey" type="dword" data="00000000"/>
 					<value name="GuiArgs" type="string" data=" /icon &quot;%CMDER_ROOT%\icons\cmder.ico&quot;"/>
-					<value name="Cmd1" type="string" data=""%ConEmuDir%\..\git-for-windows\usr\bin\bash.exe" --login -i"/>
+					<value name="Cmd1" type="string" data="&quot;%ConEmuDir%\..\git-for-windows\usr\bin\bash.exe&quot; --login -i"/>
 					<value name="Active" type="long" data="0"/>
 					<value name="Count" type="long" data="1"/>
 				</key>


### PR DESCRIPTION
ConEmu show confirmation dialog with incomplete tasks when user closes {bash::bash} console.
![image](https://user-images.githubusercontent.com/5018813/104158013-05070e80-541f-11eb-878f-d591b36bbdad.png)

It happens because some commands produces 2 or more process
```
// 3 processes
 - cmd.exe /c ""%ConEmuDir%\..\git-for-windows\bin\bash" --login -i"
 └── ...\bin\bash --login -i 
          └── ...\usr\bin\bash.exe --login -i

// 2 processes
"%ConEmuDir%\..\git-for-windows\bin\bash.exe" --login -i
 └── ...\usr\bin\bash.exe --login -i

// only 1 process
"%ConEmuDir%\..\git-for-windows\usr\bin\bash.exe" --login -i
```
If command bash hasn't extension it runs as child of cmd.exe

**I checked previous issues:**
 - [x] Worked with spaces in a path to cmder
