### PR TITLE
Fix: "The system cannot find the file specified" if %GIT_INSTALL_ROOT%\usr\bin doesn't exist

### DIFF
--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -251,9 +251,9 @@ if %nix_tools% geq 1 (
         %lib_path% enhance_path "%GIT_INSTALL_ROOT%\mingw32\bin" %path_position%
     ) else if exist "%GIT_INSTALL_ROOT%\mingw64" (
         %lib_path% enhance_path "%GIT_INSTALL_ROOT%\mingw64\bin" %path_position%
+    ) else if exist "%GIT_INSTALL_ROOT%\usr\bin" (
+        %lib_path% enhance_path "%GIT_INSTALL_ROOT%\usr\bin" %path_position%
     )
-
-    %lib_path% enhance_path "%GIT_INSTALL_ROOT%\usr\bin" %path_position%
 )
 
 :: define SVN_SSH so we can use git svn with ssh svn repositories


### PR DESCRIPTION
I have Git in my path but not through git-for-windows, I have compiled it myself. Therefore my Git isn't in a `usr/bin` structure, it's just in a folder by itself. When I run Cmder I get an annoying message on startup:

```
The system cannot find the file specified.
```

This adds a check so this message will not appear.