### PR TITLE
Fix env symbol being repeated when using a program that sets/modifies the env

### DIFF
--- a/vendor/clink.lua
+++ b/vendor/clink.lua
@@ -83,14 +83,13 @@ local function set_prompt_filter()
       cr = ' '
     end
 
-    if env ~= nil then
-        prompt_lambSymbol = "("..env..") "..prompt_lambSymbol
-    end
+    if env ~= nil then env = "("..env..") " else env = "" end
 
-    prompt = uah_color .. "{uah}" .. cwd_color .. "{cwd}{git}{hg}{svn}" .. lamb_color .. cr .. "{lamb} \x1b[0m"
-    uah_value = string.gsub(prompt, "{uah}", uah)
-    new_value = string.gsub(uah_value, "{cwd}", cwd)
-    clink.prompt.value = string.gsub(new_value, "{lamb}", prompt_lambSymbol)
+    prompt = uah_color .. "{uah}" .. cwd_color .. "{cwd}{git}{hg}{svn}" .. lamb_color .. cr .. "{env}{lamb} \x1b[0m"
+    prompt = string.gsub(prompt, "{uah}", uah)
+    prompt = string.gsub(prompt, "{cwd}", cwd)
+    prompt = string.gsub(prompt, "{env}", env)
+    clink.prompt.value = string.gsub(prompt, "{lamb}", prompt_lambSymbol)
 end
 
 local function percent_prompt_filter()


### PR DESCRIPTION
Refactor and separate the env substitution part of the Prompt.

![image](https://user-images.githubusercontent.com/22198661/116824103-0eb0af80-ab91-11eb-95e3-ba745476eedc.png)

This helps fix this weirdness that happens whenever the prompt is printed.

In the original implementation, the value `prompt_lambSymbol` has the value `"("..env..") "` appended to it all the time, but actually the variable is never reset, so it just keeps adding the env's name every time the prompt is printed.