### PR TITLE
Show branch name when cmder.status=false without expensive status ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,10 +194,11 @@ You can write `*.cmd|*.bat`, `*.ps1`, and `*.sh` scripts and just drop them in t
 
  ```
  [cmder]
-   status = false      # Opt out of Git status for 'ALL' Cmder supported shells.
-   cmdstatus = false   # Opt out of Git status for 'Cmd.exe' shells.
-   psstatus = false    # Opt out of Git status for 'Powershell.exe and 'Pwsh.exe' shells.
-   shstatus = false    # Opt out of Git status for 'bash.exe' shells.
+   status = false          # Opt out of Git status for 'ALL' Cmder supported shells.
+   cmdstatus = false       # Opt out of Git status for 'Cmd.exe' shells.
+   cmdstatus = branchonly  # Show branch name in 'Cmd.exe' shells, but don't color according to status (faster)
+   psstatus = false        # Opt out of Git status for 'Powershell.exe and 'Pwsh.exe' shells.
+   shstatus = false        # Opt out of Git status for 'bash.exe' shells.
  ```
 
 ### Aliases

--- a/README.md
+++ b/README.md
@@ -194,11 +194,10 @@ You can write `*.cmd|*.bat`, `*.ps1`, and `*.sh` scripts and just drop them in t
 
  ```
  [cmder]
-   status = false          # Opt out of Git status for 'ALL' Cmder supported shells.
-   cmdstatus = false       # Opt out of Git status for 'Cmd.exe' shells.
-   cmdstatus = branchonly  # Show branch name in 'Cmd.exe' shells, but don't color according to status (faster)
-   psstatus = false        # Opt out of Git status for 'Powershell.exe and 'Pwsh.exe' shells.
-   shstatus = false        # Opt out of Git status for 'bash.exe' shells.
+   status = false      # Opt out of Git status for 'ALL' Cmder supported shells.
+   cmdstatus = false   # Opt out of Git status for 'Cmd.exe' shells.
+   psstatus = false    # Opt out of Git status for 'Powershell.exe and 'Pwsh.exe' shells.
+   shstatus = false    # Opt out of Git status for 'bash.exe' shells.
  ```
 
 ### Aliases

--- a/vendor/cmder_prompt_config.lua.default
+++ b/vendor/cmder_prompt_config.lua.default
@@ -43,3 +43,4 @@ lamb_color = "\x1b[1;30;40m" -- Light Grey = Lambda Color
 clean_color = "\x1b[1;37;40m"
 dirty_color = "\x1b[33;3m"
 conflict_color = "\x1b[31;1m"
+unknown_color = "\x1b[30;1m"

--- a/vendor/git-prompt.sh
+++ b/vendor/git-prompt.sh
@@ -9,6 +9,21 @@ function getGitStatusSetting() {
   fi
 }
 
+function getSimpleGitBranch() {
+  gitDir=$(git rev-parse --git-dir 2>/dev/null)
+  if [ -z "$gitDir" ]; then
+		return 0
+	fi
+  
+  headContent=$(< "$gitDir/HEAD")
+  if [[ "$headContent" == "ref: refs/heads/"* ]]
+  then
+      echo " (${headContent:16})"
+  else
+      echo " (HEAD detached at ${headContent:0:7})"
+  fi 
+}
+
 if test -f /etc/profile.d/git-sdk.sh
 then
   TITLEPREFIX=SDK-${MSYSTEM#MINGW}
@@ -45,6 +60,9 @@ else
         . "$COMPLETION_PATH/git-prompt.sh"
         PS1="$PS1"'\[\033[36m\]'  # change color to cyan
         PS1="$PS1"'`__git_ps1`'   # bash function
+      else
+        PS1="$PS1"'\[\033[30;1m\]'  # change color to gray
+        PS1="$PS1"'`getSimpleGitBranch`'
       fi
     fi
   fi

--- a/vendor/psmodules/Cmder.ps1
+++ b/vendor/psmodules/Cmder.ps1
@@ -36,6 +36,14 @@ function checkGit($Path) {
 
       if (getGitStatusSetting -eq $true) {
         Write-VcsStatus
+      } else {
+        $headContent = Get-Content (Join-Path $Path '.git/HEAD')
+        if ($headContent -like "ref: refs/heads/*") {
+            $branchName = $headContent.Substring(16)
+        } else {
+            $branchName = "HEAD detached at $($headContent.Substring(0, 7))"
+        }
+        Write-Host " [$branchName]" -NoNewline -ForegroundColor DarkGray
       }
 
       return


### PR DESCRIPTION
Fixes #2548

Adds support for skipping status check (git status and git diff) when generating the prompt, while still showing the branch name.

Adds a simple mode for powershell and bash which get the branch name by just reading `.git/HEAD` which should not slow down with large repos.

I decided to change the color to gray when `status=false` to indicate that the status is unknown. This would avoid misleading people into thinking they are "clean" if they apply the config only to specific repos.