### PR TITLE
Clink async prompt

### DIFF
--- a/vendor/clink.lua
+++ b/vendor/clink.lua
@@ -42,7 +42,7 @@ local function get_conflict_color()
 end
 
 local function get_unknown_color()
-  return unknown_color or "\x1b[30;1m"
+  return unknown_color or "\x1b[37;1m"
 end
 
 ---
@@ -397,18 +397,17 @@ local function git_prompt_filter()
         clean = get_clean_color(),
         dirty = get_dirty_color(),
         conflict = get_conflict_color(),
-        unknown = get_unknown_color()
+        nostatus = get_unknown_color()
     }
 
     local git_dir = get_git_dir()
+    local color
     cmderGitStatusOptIn = get_git_status_setting()
-
     if git_dir then
-        -- if we're inside of git repo then try to detect current branch
         local branch = get_git_branch(git_dir)
-        local color = colors.unknown
         if branch then
             if cmderGitStatusOptIn then
+                -- if we're inside of git repo then try to detect current branch
                 -- Has branch => therefore it is a git folder, now figure out status
                 local gitStatus = get_git_status()
                 local gitConflict = get_git_conflict()
@@ -421,8 +420,9 @@ local function git_prompt_filter()
                 if gitConflict then
                     color = colors.conflict
                 end
+            else
+                color = colors.nostatus
             end
-
             clink.prompt.value = string.gsub(clink.prompt.value, "{git}", color.."("..verbatim(branch)..")")
             return false
         end
@@ -443,6 +443,7 @@ local function hg_prompt_filter()
         local colors = {
             clean = get_clean_color(),
             dirty = get_dirty_color(),
+            nostatus = get_unknown_color()
         }
 
         local pipe = io.popen("hg branch 2>&1")
@@ -477,6 +478,7 @@ local function svn_prompt_filter()
     local colors = {
         clean = get_clean_color(),
         dirty = get_dirty_color(),
+        nostatus = get_unknown_color()
     }
 
     if get_svn_dir() then

--- a/vendor/clink.lua
+++ b/vendor/clink.lua
@@ -41,6 +41,10 @@ local function get_conflict_color()
   return conflict_color or "\x1b[31;1m"
 end
 
+local function get_unknown_color()
+  return unknown_color or "\x1b[30;1m"
+end
+
 ---
 -- Makes a string safe to use as the replacement in string.gsub
 ---
@@ -392,34 +396,36 @@ local function git_prompt_filter()
     local colors = {
         clean = get_clean_color(),
         dirty = get_dirty_color(),
-        conflict = get_conflict_color()
+        conflict = get_conflict_color(),
+        unknown = get_unknown_color()
     }
 
     local git_dir = get_git_dir()
     cmderGitStatusOptIn = get_git_status_setting()
-    if cmderGitStatusOptIn then
-      if git_dir then
-          -- if we're inside of git repo then try to detect current branch
-          local branch = get_git_branch(git_dir)
-          local color
-          if branch then
-              -- Has branch => therefore it is a git folder, now figure out status
-              local gitStatus = get_git_status()
-              local gitConflict = get_git_conflict()
 
-              color = colors.dirty
-              if gitStatus then
-                  color = colors.clean
-              end
+    if git_dir then
+        -- if we're inside of git repo then try to detect current branch
+        local branch = get_git_branch(git_dir)
+        local color = colors.unknown
+        if branch then
+            if cmderGitStatusOptIn then
+                -- Has branch => therefore it is a git folder, now figure out status
+                local gitStatus = get_git_status()
+                local gitConflict = get_git_conflict()
 
-              if gitConflict then
-                  color = colors.conflict
-              end
+                color = colors.dirty
+                if gitStatus then
+                    color = colors.clean
+                end
 
-              clink.prompt.value = string.gsub(clink.prompt.value, "{git}", color.."("..verbatim(branch)..")")
-              return false
-          end
-      end
+                if gitConflict then
+                    color = colors.conflict
+                end
+            end
+
+            clink.prompt.value = string.gsub(clink.prompt.value, "{git}", color.."("..verbatim(branch)..")")
+            return false
+        end
     end
 
     -- No git present or not in git file

--- a/vendor/clink.lua
+++ b/vendor/clink.lua
@@ -74,9 +74,6 @@ local cached_info = {}
 if clink.promptcoroutine and io.popenyield then
     io_popenyield = io.popenyield
     clink_promptcoroutine = clink.promptcoroutine
-    if prompt_overrideGitStatusOptIn then
-        cmderForceAsyncGitStatus = true
-    end
 else
     io_popenyield = io.popen
     clink_promptcoroutine = function (func)
@@ -422,6 +419,15 @@ end
 -- @return {bool}
 ---
 local function get_git_status_setting()
+    -- When async prompt filtering is available, check the
+    -- prompt_overrideGitStatusOptIn config setting for whether to ignore the
+    -- cmder.status and cmder.cmdstatus git config opt-in settings.
+    if clink.promptcoroutine and io.popenyield and settings.get("prompt.async") then
+        if prompt_overrideGitStatusOptIn then
+            return true
+        end
+    end
+
     local gitStatusConfig = io.popen("git --no-pager config cmder.status 2>nul")
 
     for line in gitStatusConfig:lines() do
@@ -461,7 +467,7 @@ local function git_prompt_filter()
 
     local git_dir = get_git_dir()
     local color
-    cmderGitStatusOptIn = cmderForceAsyncGitStatus or get_git_status_setting()
+    cmderGitStatusOptIn = get_git_status_setting()
     if git_dir then
         local branch = get_git_branch(git_dir)
         if branch then

--- a/vendor/clink.lua
+++ b/vendor/clink.lua
@@ -74,9 +74,9 @@ local cached_info = {}
 if clink.promptcoroutine and io.popenyield then
     io_popenyield = io.popenyield
     clink_promptcoroutine = clink.promptcoroutine
-    -- Uncommenting this will override the cmderGitStatusOptIn and always show
-    -- git status when Clink is able to run it in the background.
-    --cmderForceAsyncGitStatus = true
+    if prompt_overrideGitStatusOptIn then
+        cmderForceAsyncGitStatus = true
+    end
 else
     io_popenyield = io.popen
     clink_promptcoroutine = function (func)

--- a/vendor/cmder_prompt_config.lua.default
+++ b/vendor/cmder_prompt_config.lua.default
@@ -29,6 +29,11 @@ prompt_useUserAtHost = false
  -- default is false
 prompt_singleLine = false
 
+-- OPTIONAL. If true then always ignore the cmder.status and cmder.cmdstatus git config settings and run the git prompt commands in the background.
+ -- default is false
+ -- NOTE: This only takes effect if using Clink v1.2.10 or higher.
+prompt_overrideGitStatusOptIn = false
+
 -- Prompt Attributes
 --
 -- Colors

--- a/vendor/cmder_prompt_config.lua.default
+++ b/vendor/cmder_prompt_config.lua.default
@@ -34,6 +34,10 @@ prompt_singleLine = false
  -- NOTE: This only takes effect if using Clink v1.2.10 or higher.
 prompt_overrideGitStatusOptIn = false
 
+-- OPTIONAL. If true then Cmder includes git, mercurial, and subversion status in the prompt.
+ -- default is true
+prompt_includeVersionControl = true
+
 -- Prompt Attributes
 --
 -- Colors

--- a/vendor/cmder_prompt_config.lua.default
+++ b/vendor/cmder_prompt_config.lua.default
@@ -43,4 +43,4 @@ lamb_color = "\x1b[1;30;40m" -- Light Grey = Lambda Color
 clean_color = "\x1b[1;37;40m"
 dirty_color = "\x1b[33;3m"
 conflict_color = "\x1b[31;1m"
-unknown_color = "\x1b[30;1m"
+unknown_color = "\x1b[37;1m" -- White = No VCS Status Branch Color

--- a/vendor/cmder_prompt_config.lua.default
+++ b/vendor/cmder_prompt_config.lua.default
@@ -43,3 +43,4 @@ lamb_color = "\x1b[1;30;40m" -- Light Grey = Lambda Color
 clean_color = "\x1b[1;37;40m"
 dirty_color = "\x1b[33;3m"
 conflict_color = "\x1b[31;1m"
+unknown_color = "\x1b[30;1m"

--- a/vendor/git-prompt.sh
+++ b/vendor/git-prompt.sh
@@ -9,6 +9,21 @@ function getGitStatusSetting() {
   fi
 }
 
+function getSimpleGitBranch() {
+  gitDir=$(git rev-parse --git-dir 2>/dev/null)
+  if [ -z "$gitDir" ]; then
+		return 0
+	fi
+  
+  headContent=$(< "$gitDir/HEAD")
+  if [[ "$headContent" == "ref: refs/heads/"* ]]
+  then
+      echo " (${headContent:16})"
+  else
+      echo " (HEAD detached at ${headContent:0:7})"
+  fi 
+}
+
 if test -f /etc/profile.d/git-sdk.sh
 then
   TITLEPREFIX=SDK-${MSYSTEM#MINGW}
@@ -45,6 +60,9 @@ else
         . "$COMPLETION_PATH/git-prompt.sh"
         PS1="$PS1"'\[\033[36m\]'  # change color to cyan
         PS1="$PS1"'`__git_ps1`'   # bash function
+      else
+        PS1="$PS1"'\[\033[30;1m\]'  # change color to gray
+        PS1="$PS1"'`getSimpleGitBranch`'
       fi
     fi
   fi

--- a/vendor/git-prompt.sh
+++ b/vendor/git-prompt.sh
@@ -61,7 +61,7 @@ else
         PS1="$PS1"'\[\033[36m\]'  # change color to cyan
         PS1="$PS1"'`__git_ps1`'   # bash function
       else
-        PS1="$PS1"'\[\033[30;1m\]'  # change color to gray
+        PS1="$PS1"'\[\033[37;1m\]'  # change color to white
         PS1="$PS1"'`getSimpleGitBranch`'
       fi
     fi

--- a/vendor/psmodules/Cmder.ps1
+++ b/vendor/psmodules/Cmder.ps1
@@ -36,6 +36,14 @@ function checkGit($Path) {
 
       if (getGitStatusSetting -eq $true) {
         Write-VcsStatus
+      } else {
+        $headContent = Get-Content (Join-Path $Path '.git/HEAD')
+        if ($headContent -like "ref: refs/heads/*") {
+            $branchName = $headContent.Substring(16)
+        } else {
+            $branchName = "HEAD detached at $($headContent.Substring(0, 7))"
+        }
+        Write-Host " [$branchName]" -NoNewline -ForegroundColor DarkGray
       }
 
       return

--- a/vendor/psmodules/Cmder.ps1
+++ b/vendor/psmodules/Cmder.ps1
@@ -43,7 +43,7 @@ function checkGit($Path) {
         } else {
             $branchName = "HEAD detached at $($headContent.Substring(0, 7))"
         }
-        Write-Host " [$branchName]" -NoNewline -ForegroundColor DarkGray
+        Write-Host " [$branchName]" -NoNewline -ForegroundColor White
       }
 
       return


### PR DESCRIPTION
# Description
This PR adds support in Cmder for the new "asynchronous prompt filtering" in Clink v1.2.10 and higher.  It should be forward/backward compatible with other versions of Clink.

Now the potentially slow `git status` (etc) commands are run in the background, so there's no waiting for the prompt to show up.  When the background commands finish, the prompt gets refreshed.  To avoid unnecessary flicker, the most recent results are cached so they can be used while waiting for new background commands to finish (switching repos or branches resets the cached results).

The new async prompt filtering is enabled by default in Clink, but prompt filters must opt in to use it (which is what this PR does for Cmder's git prompt).  It can be turned off via `clink set prompt.async false`.  See [Asynchronous Prompt Filtering](https://chrisant996.github.io/clink/clink.html#asyncpromptfiltering) for more info.

# Merge Notes
This PR is based on the pending PR https://github.com/cmderdev/cmder/pull/2549.  When applied _after_ https://github.com/cmderdev/cmder/pull/2549 is committed, I expect this PR should encounter few-or-no merge conflicts.  But if it does encounter merge conflicts, let me know and I can resolve them.

# Test Notes
- [x] Tested Cmder 1.3.18 with this change and Clink v1.1.45 (what it currently includes -- which is still a pre-release build of Clink).
- [x] Tested Cmder 1.3.18 with this change and Clink v1.2.10 (latest release build).
  - [x] Tested with `prompt.async` setting **true** (the default).
  - [x] Tested with `prompt.async` setting **false**.

Everything looks good to me.