### PR TITLE
Update clink to 1.2.22

### DIFF
--- a/vendor/sources.json
+++ b/vendor/sources.json
@@ -6,8 +6,8 @@
     },
     {
         "name": "clink",
-        "version": "1.2.20",
-        "url": "https://github.com/chrisant996/clink/releases/download/v1.2.20/clink.1.2.20.801802.zip"
+        "version": "1.2.22",
+        "url": "https://github.com/chrisant996/clink/releases/download/v1.2.22/clink.1.2.22.890a84.zip"
     },
     {
         "name": "conemu-maximus5",

--- a/vendor/sources.json
+++ b/vendor/sources.json
@@ -6,8 +6,8 @@
     },
     {
         "name": "clink",
-        "version": "1.2.5",
-        "url": "https://github.com/chrisant996/clink/releases/download/v1.2.5/clink.1.2.5.5dd017.zip"
+        "version": "1.2.20",
+        "url": "https://github.com/chrisant996/clink/releases/download/v1.2.20/clink.1.2.20.801802.zip"
     },
     {
         "name": "conemu-maximus5",


### PR DESCRIPTION
Latest update of clink contains some interesting changes. 
Mainly the ability to [complete on doskey aliases ](https://github.com/chrisant996/clink/issues/119)