### PR TITLE
Fix Posh-Git 1.0.0 import and console.

### DIFF
--- a/vendor/psmodules/Cmder.ps1
+++ b/vendor/psmodules/Cmder.ps1
@@ -21,6 +21,10 @@ function Import-Git(){
     if($GitModule | select version | where version -le ([version]"0.6.1.20160330")){
         Import-Module Posh-Git > $null
     }
+    if($GitModule | select version | where version -ge ([version]"1.0.0")){
+        Import-Module Posh-Git > $null
+        $GitPromptSettings.AnsiConsole = $false
+    }
     if(-not ($GitModule) ) {
         Write-Warning "Missing git support, install posh-git with 'Install-Module posh-git' and restart cmder."
     }


### PR DESCRIPTION
Posh-Git 1.0.0 was released back in March and it breaks on this line: https://github.com/cmderdev/cmder/blob/2ef8c967d2dd203869c411ca56bddfad6d505855/vendor/psmodules/Cmder.ps1#L21

Don't really know why it was important to import module before version 0.6.1.20160330 but with 1.0.0 it is needed again and additionally `$GitPromptSettings.AnsiConsole` needs to be set to `false` for the status to be displayed in path line rather than input line.

Without fix:
![image](https://user-images.githubusercontent.com/1806798/131455732-15417536-eb1c-442f-8285-6ed70faecaa2.png)

With fix:
![image](https://user-images.githubusercontent.com/1806798/131455639-c75cd8d5-7ef5-433e-90aa-6d3b69e6358d.png)
