### PR TITLE
Fix a problem with an ampersand character in path

### DIFF
--- a/vendor/lib/lib_path.cmd
+++ b/vendor/lib/lib_path.cmd
@@ -74,7 +74,7 @@ exit /b
     set "find_query=%add_to_path%"
     set "find_query=%find_query:\=\\%"
     set "find_query=%find_query: =\ %"
-    set OLD_PATH=%PATH%
+    set "OLD_PATH=%PATH%"
 
     setlocal enabledelayedexpansion
     if "!found!" == "0" (
@@ -121,8 +121,8 @@ exit /b
     exit /b
 
     :toolong
-      echo %OLD_PATH%>tempfileA
-      echo %PATH%>tempfileB
+      echo "%OLD_PATH%">tempfileA
+      echo "%PATH%">tempfileB
       fc /b tempfileA tempfileB 2>nul 1>nul
       if errorlevel 1 ( del tempfileA & del tempfileB & goto :changed )
       del tempfileA & del tempfileB


### PR DESCRIPTION
If the path variable contained values with an ampersand character (such as in the case of MySQL), the string splits by this character, and tries to execute what follows as a separate command. 
All occurrences of the set command containing %PATH% should be wrapped in quotation marks