### PR TITLE
Fix #2654: blank space added between {cwd} and version_control variable

### DIFF
--- a/vendor/clink.lua
+++ b/vendor/clink.lua
@@ -166,7 +166,7 @@ local function set_prompt_filter()
     if uah ~= '' then uah = get_uah_color() .. uah end
     if cwd ~= '' then cwd = get_cwd_color() .. cwd end
 
-    local version_control = prompt_includeVersionControl and "{git}{hg}{svn}" or ""
+    local version_control = prompt_includeVersionControl and " {git}{hg}{svn}" or ""
 
     prompt = "{uah}{cwd}" .. version_control .. get_lamb_color() .. cr .. "{env}{lamb} \x1b[0m"
     prompt = string.gsub(prompt, "{uah}", uah)


### PR DESCRIPTION
Sorry for the inconveniences, but development branch seems way off. This is the reason I'm targeting master, which contradicts with the [contribution guidelines](https://github.com/cmderdev/cmder/blob/711fe2895e5331e183ee72c200a3f67349f1fa12/CONTRIBUTING.md#submitting-changes).