### PR TITLE
Fix git worktree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [Unreleased](https://ci.appveyor.com/project/MartiUK/cmder/build/artifacts) (2022-03-17)
+
+### Changes
+
+- Fix Git prompt branch when using Git worktree.
+
 ## [1.3.19](https://github.com/cmderdev/cmder/tree/v1.3.19) (2022-01-15)
 
 ### Changes

--- a/vendor/clink.lua
+++ b/vendor/clink.lua
@@ -256,6 +256,12 @@ local function get_git_dir(path)
         local git_dir = gitfile:read():match('gitdir: (.*)')
         gitfile:close()
 
+        if os.isdir then -- only available in Clink v1.0.0 and higher
+            if git_dir and os.isdir(git_dir) then
+                return git_dir
+            end
+        end
+
         return git_dir and dir..'/'..git_dir
     end
 


### PR DESCRIPTION
## [Unreleased](https://ci.appveyor.com/project/MartiUK/cmder/build/artifacts) (2022-03-17)

### Changes

- Fix Git prompt branch when using Git worktree.