### PR TITLE
Update Git for Windows and Clink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased](https://ci.appveyor.com/project/MartiUK/cmder/build/artifacts) (2022-03-17)
 
+### Changes
+
+- Update Git for Windows to 2.36.0
+- Update to Clink 1.3.16
+
 ### Fixes
 
 - Fix find and use latest Git install always using vendored Git.
@@ -15,7 +20,7 @@
 ### Changes
 
 - Update Git for Windows to 2.34.0
-- Update to Clink 1.3.15
+- Update to Clink 1.2.46
 - Update to stable Conemu 210912
 - Do not rely on having a `%cmder_root%\config\cmder_prompt_config.lua`
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Join the chat at https://gitter.im/cmderdev/cmder](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/cmderdev/cmder?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Build Status](https://ci.appveyor.com/api/projects/status/github/cmderdev/cmder?branch=master&svg=true)](https://ci.appveyor.com/project/MartiUK/cmder)
 
-Cmder is a **software package** created out of pure frustration over absence of usable console emulator on Windows. It is based on [ConEmu](https://conemu.github.io/) with *major* config overhaul, comes with a Monokai color scheme, amazing [clink](https://github.com/mridgers/clink) (further enhanced by [clink-completions](https://github.com/vladimir-kotikov/clink-completions)) and a custom prompt layout.
+Cmder is a **software package** created out of pure frustration over absence of usable console emulator on Windows. It is based on [ConEmu](https://conemu.github.io/) with *major* config overhaul, comes with a Monokai color scheme, amazing [clink](https://chrisant996.github.io/clink/) (further enhanced by [clink-completions](https://github.com/vladimir-kotikov/clink-completions)) and a custom prompt layout.
 
 ![Cmder Screenshot](http://i.imgur.com/g1nNf0I.png)
 

--- a/vendor/sources.json
+++ b/vendor/sources.json
@@ -1,8 +1,8 @@
 [
     {
         "name": "git-for-windows",
-        "version": "v2.34.0.windows.1",
-        "url": "https://github.com/git-for-windows/git/releases/download/v2.34.0.windows.1/PortableGit-2.34.0-64-bit.7z.exe"
+        "version": "v2.36.0.windows.1",
+        "url": "https://github.com/git-for-windows/git/releases/download/v2.36.0.windows.1/PortableGit-2.36.0-64-bit.7z.exe"
     },
     {
         "name": "clink",

--- a/vendor/sources.json
+++ b/vendor/sources.json
@@ -6,8 +6,8 @@
     },
     {
         "name": "clink",
-        "version": "1.3.15",
-        "url": "https://github.com/chrisant996/clink/releases/download/v1.3.15/clink.1.3.15.6e6e45.zip"
+        "version": "1.3.16",
+        "url": "https://github.com/chrisant996/clink/releases/download/v1.3.16/clink.1.3.16.023688.zip"
     },
     {
         "name": "conemu-maximus5",


### PR DESCRIPTION
Updates Clink to 1.3.16 and updates Git for Windows to 2.36.0

this pull request also changes the Clink URL in the readme to point to the new maintained version of Clink that is in use by Cmder.