### PR TITLE
Add optional clink async prompt update for svn status

### DIFF
--- a/vendor/cmder_prompt_config.lua.default
+++ b/vendor/cmder_prompt_config.lua.default
@@ -29,14 +29,19 @@ prompt_useUserAtHost = false
  -- default is false
 prompt_singleLine = false
 
+-- OPTIONAL. If true then Cmder includes git, mercurial, and subversion status in the prompt.
+ -- default is true
+prompt_includeVersionControl = true
+
 -- OPTIONAL. If true then always ignore the cmder.status and cmder.cmdstatus git config settings and run the git prompt commands in the background.
  -- default is false
  -- NOTE: This only takes effect if using Clink v1.2.10 or higher.
 prompt_overrideGitStatusOptIn = false
 
--- OPTIONAL. If true then Cmder includes git, mercurial, and subversion status in the prompt.
- -- default is true
-prompt_includeVersionControl = true
+-- OPTIONAL. If true then always ignore the cmder.status and cmder.cmdstatus svn config settings and run the svn prompt commands in the background.
+ -- default is false
+ -- NOTE: This only takes effect if using Clink v1.2.10 or higher.
+prompt_overrideSvnStatusOptIn = false
 
 -- Prompt Attributes
 --


### PR DESCRIPTION
As discussed in #2702, svn status can take quite some time. This change aims to optionally perform svn status check asynchronously, like it's provided for git status.

In the setting file I've move `prompt_includeVersionControl` up as it makes sense to decide on that before deciding if sync or async update should be used. I've added a new setting for svn status update.
In `clink.lua` this new setting is used to decide if the status should be checked asynchronously or blocking. Similar caching mechanism than git is used too.

I've done limited testing with the different svn repo I have and it seems to behave. Please propose improvement if needed.