### PR TITLE
Update Vendor

### DIFF
--- a/vendor/sources.json
+++ b/vendor/sources.json
@@ -1,18 +1,18 @@
 [
     {
         "name": "git-for-windows",
-        "version": "v2.36.0.windows.1",
-        "url": "https://github.com/git-for-windows/git/releases/download/v2.36.0.windows.1/PortableGit-2.36.0-64-bit.7z.exe"
+        "version": "v2.36.1.windows.1",
+        "url": "https://github.com/git-for-windows/git/releases/download/v2.36.1.windows.1/PortableGit-2.36.1-64-bit.7z.exe"
     },
     {
         "name": "clink",
-        "version": "1.3.16",
-        "url": "https://github.com/chrisant996/clink/releases/download/v1.3.16/clink.1.3.16.023688.zip"
+        "version": "1.3.17",
+        "url": "https://github.com/chrisant996/clink/releases/download/v1.3.17/clink.1.3.17.0a95d0.zip"
     },
     {
         "name": "conemu-maximus5",
-        "version": "210912",
-        "url": "https://github.com/Maximus5/ConEmu/releases/download/v21.09.12/ConEmuPack.210912.7z"
+        "version": "220418",
+        "url": "https://github.com/Maximus5/ConEmu/releases/download/v22.04.18/ConEmuPack.220418.7z"
     },
     {
         "name": "clink-completions",


### PR DESCRIPTION
Update: git-for-windows to 2.36.1, Clink to 1.3.17, ConEmu to 220418