### PR TITLE
Related to #2654: Move space from "{git}{hg}{svn}" to individual parts

### DIFF
--- a/vendor/clink.lua
+++ b/vendor/clink.lua
@@ -166,7 +166,7 @@ local function set_prompt_filter()
     if uah ~= '' then uah = get_uah_color() .. uah end
     if cwd ~= '' then cwd = get_cwd_color() .. cwd end
 
-    local version_control = prompt_includeVersionControl and " {git}{hg}{svn}" or ""
+    local version_control = prompt_includeVersionControl and "{git}{hg}{svn}" or ""
 
     prompt = "{uah}{cwd}" .. version_control .. get_lamb_color() .. cr .. "{env}{lamb} \x1b[0m"
     prompt = string.gsub(prompt, "{uah}", uah)
@@ -507,7 +507,7 @@ local function git_prompt_filter()
             else
                 color = colors.nostatus
             end
-            clink.prompt.value = string.gsub(clink.prompt.value, "{git}", color.."("..verbatim(branch)..")")
+            clink.prompt.value = string.gsub(clink.prompt.value, "{git}", " "..color.."("..verbatim(branch)..")")
             return false
         end
     end
@@ -555,7 +555,7 @@ local function hg_prompt_filter()
         end
     end
 
-    clink.prompt.value = string.gsub(clink.prompt.value, "{hg}", verbatim(result))
+    clink.prompt.value = string.gsub(clink.prompt.value, "{hg}", " "..verbatim(result))
     return false
 end
 
@@ -609,7 +609,7 @@ local function svn_prompt_filter()
                 color = colors.dirty
             end
 
-            clink.prompt.value = string.gsub(clink.prompt.value, "{svn}", color.."("..verbatim(branch)..")")
+            clink.prompt.value = string.gsub(clink.prompt.value, "{svn}", " "..color.."("..verbatim(branch)..")")
             return false
         end
     end


### PR DESCRIPTION
### Description
This PR moves the space from the `"{git}{hg}{svn}"` part to the individual `{git}`, `{hg}` and `{svn}` parts

Related to #2654

### Reasoning
- If the directory contains multiple CVS software, this ensures proper spacing between each prompt part
- avoid prepending extra space to the prompt in case the directory has not CVS software (e.g. not a git directory)