### PR TITLE
Improvements to Cmder prompt

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # How to contribute
 
-Unfortunately we all can't work on cmder every day of the year, so I have decided to write some guidelines for contributing.
+Unfortunately we all can't work on Cmder every day of the year, so I have decided to write some guidelines for contributing.
 
 If you follow them your contribution will likely be pulled in quicker.
 

--- a/Cmder.bat
+++ b/Cmder.bat
@@ -5,7 +5,7 @@ SET CMDER_ROOT=%~dp0
 @if "%CMDER_ROOT:~-1%" == "\" SET CMDER_ROOT=%CMDER_ROOT:~0,-1%
 
 if not exist "%CMDER_ROOT%\config\user_ConEmu.xml" (
-  copy "%CMDER_ROOT%\vendor\ConEmu.xml.default" "%CMDER_ROOT%\config\user_ConEmu.xml"
+    copy "%CMDER_ROOT%\vendor\ConEmu.xml.default" "%CMDER_ROOT%\config\user_ConEmu.xml"
 )
 
 if exist "%~1" (

--- a/scripts/utils.ps1
+++ b/scripts/utils.ps1
@@ -98,8 +98,8 @@ function Get-VersionStr {
 
     # Determine if git is available
     if (Get-Command "git.exe" -ErrorAction SilentlyContinue) {
-        # Determine if the current diesctory is a git repository
-        $GitPresent = Invoke-Expression "git rev-parse --is-inside-work-tree" -erroraction SilentlyContinue
+        # Determine if the current directory is a git repository
+        $GitPresent = Invoke-Expression "git rev-parse --is-inside-work-tree" -ErrorAction SilentlyContinue
 
         if ( $GitPresent -eq 'true' ) {
             $string = Invoke-Expression "git describe --abbrev=0 --tags"

--- a/vendor/clink.lua
+++ b/vendor/clink.lua
@@ -15,34 +15,34 @@ dofile(clink_lua_file)
 
 
 local function get_uah_color()
-  return uah_color or "\x1b[1;33;49m" -- Green = uah = [user]@[hostname]
+    return uah_color or "\x1b[1;33;49m" -- Green = uah = [user]@[hostname]
 end
 
 local function get_cwd_color()
-  return cwd_color or "\x1b[1;32;49m" -- Yellow cwd = Current Working Directory
+    return cwd_color or "\x1b[1;32;49m" -- Yellow cwd = Current Working Directory
 end
 
 local function get_lamb_color()
-  return lamb_color or "\x1b[1;30;49m" -- Light Grey = Lambda Color
+    return lamb_color or "\x1b[1;30;49m" -- Light Grey = Lambda Color
 end
 
 
 local function get_clean_color()
-  return clean_color or "\x1b[1;37;49m"
+    return clean_color or "\x1b[1;37;49m"
 end
 
 
 local function get_dirty_color()
-  return dirty_color or "\x1b[33;3m"
+    return dirty_color or "\x1b[33;3m"
 end
 
 
 local function get_conflict_color()
-  return conflict_color or "\x1b[31;1m"
+    return conflict_color or "\x1b[31;1m"
 end
 
 local function get_unknown_color()
-  return unknown_color or "\x1b[37;1m"
+    return unknown_color or "\x1b[37;1m"
 end
 
 ---
@@ -57,9 +57,9 @@ end
 -- Ex: Input C:\Windows\System32 returns System32
 ---
 local function get_folder_name(path)
-  local reversePath = string.reverse(path)
-  local slashIndex = string.find(reversePath, "\\")
-  return string.sub(path, string.len(path) - slashIndex + 2)
+    local reversePath = string.reverse(path)
+    local slashIndex = string.find(reversePath, "\\")
+    return string.sub(path, string.len(path) - slashIndex + 2)
 end
 
 
@@ -115,32 +115,32 @@ local function set_prompt_filter()
     -- Much of the below was 'borrowed' from https://github.com/AmrEldib/cmder-powerline-prompt
     -- Symbol displayed for the home dir in the prompt.
     if not prompt_homeSymbol then
-      prompt_homeSymbol = "~"
+        prompt_homeSymbol = "~"
     end
 
     -- Symbol displayed in the new line below the prompt.
     if not prompt_lambSymbol then
-      prompt_lambSymbol = "λ"
+        prompt_lambSymbol = "λ"
     end
 
     if not prompt_type then
-      prompt_type = "full"
+        prompt_type = "full"
     end
 
     if prompt_useHomeSymbol == nil then
-      prompt_useHomeSymbol = false
+        prompt_useHomeSymbol = false
     end
 
     if prompt_useUserAtHost == nil then
-      prompt_useUserAtHost = false
+        prompt_useUserAtHost = false
     end
 
     if prompt_singleLine == nil then
-      prompt_singleLine = false
+        prompt_singleLine = false
     end
 
     if prompt_includeVersionControl == nil then
-      prompt_includeVersionControl = true
+        prompt_includeVersionControl = true
     end
 
     if prompt_type == 'folder' then
@@ -158,8 +158,10 @@ local function set_prompt_filter()
 
     cr = "\n"
     if prompt_singleLine then
-      cr = ' '
+        cr = ' '
     end
+
+    cr = "\x1b[0m" .. cr
 
     if env ~= nil then env = "("..env..") " else env = "" end
 
@@ -168,7 +170,7 @@ local function set_prompt_filter()
 
     local version_control = prompt_includeVersionControl and "{git}{hg}{svn}" or ""
 
-    prompt = "{uah}{cwd}" .. version_control .. get_lamb_color() .. cr .. "{env}{lamb} \x1b[0m"
+    prompt = "{uah}{cwd}" .. version_control .. cr .. get_lamb_color() .. "{env}{lamb}\x1b[0m "
     prompt = string.gsub(prompt, "{uah}", uah)
     prompt = string.gsub(prompt, "{cwd}", cwd)
     prompt = string.gsub(prompt, "{env}", env)
@@ -363,12 +365,12 @@ local function get_git_status()
         local code = line:sub(1, 2)
         -- print (string.format("code: %s, line: %s", code, line))
         if code == "DD" or code == "AU" or code == "UD" or code == "UA" or code == "DU" or code == "AA" or code == "UU" then
-          is_status = false
-          conflict_found = true
-          break
+            is_status = false
+            conflict_found = true
+            break
         -- unversioned files are ignored, comment out 'code ~= "!!"' to unignore them
         elseif code ~= "!!" and code ~= "??" then
-          is_status = false
+            is_status = false
         end
     end
     file:close()
@@ -440,16 +442,16 @@ local function get_git_status_setting()
 
     for line in gitStatusConfig:lines() do
         if string.match(line, 'false') then
-          gitStatusConfig:close()
-          return false
+            gitStatusConfig:close()
+            return false
         end
     end
 
     local gitCmdStatusConfig = io.popen("git --no-pager config cmder.cmdstatus 2>nul")
     for line in gitCmdStatusConfig:lines() do
         if string.match(line, 'false') then
-          gitCmdStatusConfig:close()
-          return false
+            gitCmdStatusConfig:close()
+            return false
         end
     end
     gitStatusConfig:close()
@@ -640,11 +642,11 @@ for _,lua_module in ipairs(clink.find_files(completions_dir..'*.lua')) do
 end
 
 if clink.get_env('CMDER_USER_CONFIG') then
-  local cmder_config_dir = clink.get_env('CMDER_ROOT')..'/config/'
-  for _,lua_module in ipairs(clink.find_files(cmder_config_dir..'*.lua')) do
-    local filename = cmder_config_dir..lua_module
-    -- use dofile instead of require because require caches loaded modules
-    -- so config reloading using Alt-Q won't reload updated modules.
-    dofile(filename)
-  end
+    local cmder_config_dir = clink.get_env('CMDER_ROOT')..'/config/'
+    for _,lua_module in ipairs(clink.find_files(cmder_config_dir..'*.lua')) do
+        local filename = cmder_config_dir..lua_module
+        -- use dofile instead of require because require caches loaded modules
+        -- so config reloading using Alt-Q won't reload updated modules.
+        dofile(filename)
+    end
 end

--- a/vendor/clink_settings.default
+++ b/vendor/clink_settings.default
@@ -17,3 +17,12 @@ history.max_lines = 10000
 # name: Share history between instances
 # type: boolean
 history.shared = True
+
+# name: Auto-answer terminate prompt
+# type: enum
+# options: off,answer_yes,answer_no
+cmd.auto_answer = answer_yes
+
+# name: Doskey completions
+# type: color
+color.doskey = yellow

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -129,10 +129,15 @@ goto var_loop
 %print_debug% init.bat "Env Var - CMDER_ROOT=%CMDER_ROOT%"
 %print_debug% init.bat "Env Var - debug_output=%debug_output%"
 
+:: Sets Cmder directory paths
+SET CMDER_CONFIG_DIR=%CMDER_ROOT%\config
+
+:: Check if wre're using Cmder individual user profile
 if defined CMDER_USER_CONFIG (
     %print_debug% init.bat "CMDER IS ALSO USING INDIVIDUAL USER CONFIG FROM '%CMDER_USER_CONFIG%'!"
 
     if not exist "%CMDER_USER_CONFIG%\..\opt" md "%CMDER_USER_CONFIG%\..\opt"
+    set CMDER_CONFIG_DIR=%CMDER_USER_CONFIG%
 )
 
 :: Pick right version of Clink
@@ -153,53 +158,28 @@ if "%CMDER_CLINK%" == "1" (
     )
 
     :: Run Clink
-    if defined CMDER_USER_CONFIG (
-        if not exist "%CMDER_USER_CONFIG%\settings" if not exist "%CMDER_USER_CONFIG%\clink_settings" (
-            echo Generating Clink initial settings in "%CMDER_USER_CONFIG%\clink_settings"
-            copy "%CMDER_ROOT%\vendor\clink_settings.default" "%CMDER_USER_CONFIG%\clink_settings"
-            echo Additional *.lua files in "%CMDER_USER_CONFIG%" are loaded on startup.
-        )
-
-        if not exist "%CMDER_USER_CONFIG%\cmder_prompt_config.lua" (
-            echo Creating Cmder prompt config file: "%CMDER_USER_CONFIG%\cmder_prompt_config.lua"
-            copy "%CMDER_ROOT%\vendor\cmder_prompt_config.lua.default" "%CMDER_USER_CONFIG%\cmder_prompt_config.lua"
-        )
-
-        REM Cleanup lagacy Clink Settings file
-        if exist "%CMDER_USER_CONFIG%\settings" if exist "%CMDER_USER_CONFIG%\clink_settings" (
-            del "%CMDER_USER_CONFIG%\settings"
-        )
-
-        REM Cleanup legacy Clink history file
-        if exist "%CMDER_USER_CONFIG%\.history" if exist "%CMDER_USER_CONFIG%\clink_history" (
-            del "%CMDER_USER_CONFIG%\.history"
-        )
-
-        "%CMDER_ROOT%\vendor\clink\clink_%clink_architecture%.exe" inject --quiet --profile "%CMDER_USER_CONFIG%" --scripts "%CMDER_ROOT%\vendor"
-    ) else (
-        if not exist "%CMDER_ROOT%\config\settings" if not exist "%CMDER_ROOT%\config\clink_settings" (
-            echo Generating Clink initial settings in "%CMDER_ROOT%\config\clink_settings"
-            copy "%CMDER_ROOT%\vendor\clink_settings.default" "%CMDER_ROOT%\config\clink_settings"
-            echo Additional *.lua files in "%CMDER_ROOT%\config" are loaded on startup.
-        )
-
-        if not exist "%CMDER_ROOT%\config\cmder_prompt_config.lua" (
-            echo Creating Cmder prompt config file: "%CMDER_ROOT%\config\cmder_prompt_config.lua"
-            copy "%CMDER_ROOT%\vendor\cmder_prompt_config.lua.default" "%CMDER_ROOT%\config\cmder_prompt_config.lua"
-        )
-
-        REM Cleanup lagacy Clink Settings file
-            if exist "%CMDER_ROOT%\config\settings" if exist "%CMDER_ROOT%\config\clink_settings" (
-            del "%CMDER_ROOT%\config\settings"
-        )
-
-        REM Cleanup legacy Clink history file
-            if exist "%CMDER_ROOT%\config\.history" if exist "%CMDER_ROOT%\config\clink_history" (
-            del "%CMDER_ROOT%\config\.history"
-        )
-
-        "%CMDER_ROOT%\vendor\clink\clink_%clink_architecture%.exe" inject --quiet --profile "%CMDER_ROOT%\config" --scripts "%CMDER_ROOT%\vendor"
+    if not exist "%CMDER_CONFIG_DIR%\settings" if not exist "%CMDER_CONFIG_DIR%\clink_settings" (
+        echo Generating Clink initial settings in "%CMDER_CONFIG_DIR%\clink_settings"
+        copy "%CMDER_ROOT%\vendor\clink_settings.default" "%CMDER_CONFIG_DIR%\clink_settings"
+        echo Additional *.lua files in "%CMDER_CONFIG_DIR%" are loaded on startup.
     )
+
+    if not exist "%CMDER_CONFIG_DIR%\cmder_prompt_config.lua" (
+        echo Creating Cmder prompt config file: "%CMDER_CONFIG_DIR%\cmder_prompt_config.lua"
+        copy "%CMDER_ROOT%\vendor\cmder_prompt_config.lua.default" "%CMDER_CONFIG_DIR%\cmder_prompt_config.lua"
+    )
+
+    :: Cleanup lagacy Clink Settings file
+    if exist "%CMDER_CONFIG_DIR%\settings" if exist "%CMDER_CONFIG_DIR%\clink_settings" (
+        del "%CMDER_CONFIG_DIR%\settings"
+    )
+
+    :: Cleanup legacy Clink history file
+    if exist "%CMDER_CONFIG_DIR%\.history" if exist "%CMDER_CONFIG_DIR%\clink_history" (
+        del "%CMDER_CONFIG_DIR%\.history"
+    )
+
+    "%CMDER_ROOT%\vendor\clink\clink_%clink_architecture%.exe" inject --quiet --profile "%CMDER_CONFIG_DIR%" --scripts "%CMDER_ROOT%\vendor"
 
     if errorlevel 1 (
         %print_error% "Failed to initialize Clink with error code: %errorlevel%"
@@ -361,11 +341,7 @@ if defined CMDER_USER_CONFIG (
 :: must also be self executing, see '.\user_aliases.cmd.default',
 :: and be in profile.d folder.
 if not defined user_aliases (
-    if defined CMDER_USER_CONFIG (
-        set "user_aliases=%CMDER_USER_CONFIG%\user_aliases.cmd"
-    ) else (
-        set "user_aliases=%CMDER_ROOT%\config\user_aliases.cmd"
-    )
+    set "user_aliases=%CMDER_CONFIG_DIR%\user_aliases.cmd"
 )
 
 if "%CMDER_ALIASES%" == "1" (

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -155,7 +155,7 @@ if "%CMDER_CLINK%" == "1" (
     :: Run Clink
     if defined CMDER_USER_CONFIG (
         if not exist "%CMDER_USER_CONFIG%\settings" if not exist "%CMDER_USER_CONFIG%\clink_settings" (
-            echo Generating clink initial settings in "%CMDER_USER_CONFIG%\clink_settings"
+            echo Generating Clink initial settings in "%CMDER_USER_CONFIG%\clink_settings"
             copy "%CMDER_ROOT%\vendor\clink_settings.default" "%CMDER_USER_CONFIG%\clink_settings"
             echo Additional *.lua files in "%CMDER_USER_CONFIG%" are loaded on startup.
         )

--- a/vendor/user_aliases.cmd.default
+++ b/vendor/user_aliases.cmd.default
@@ -6,6 +6,7 @@
 ;= Add aliases below here
 e.=explorer .
 gl=git log --oneline --all --graph --decorate  $*
+l=ls --show-control-chars -CFGNhp --color --ignore={"NTUSER.DAT*","ntuser.dat*"} $*
 ls=ls --show-control-chars -F --color $*
 pwd=cd
 clear=cls


### PR DESCRIPTION
## Powershell prompt
- Added color to the **PS** prefix in prompt, if the Administrator privileges are present.

   ### Example
   <img src="https://user-images.githubusercontent.com/4673812/197581311-f0dbfd61-64f5-4517-b322-0a53f979221f.png" width=280/>


## Clink prompt
- Fixed a problem where the _iralic_ style of git status would bleed into the **λ** prompt.

   ### Before
   <img src="https://user-images.githubusercontent.com/4673812/197579724-5df8042b-452f-4138-9665-0148a49fa3a2.png" width=486/>

   ### After
   <img src="https://user-images.githubusercontent.com/4673812/197579745-d79a7e06-136d-4501-b883-01563e239458.png" width=486/>

- Turn on auto answer to Ctrl+C by default (#1666)

- Use `yellow` color value for alias highlighting to be more consistent with Powershell

- Added new `l` alias:
  ```bash
  ls --show-control-chars -CFGNhp --color --ignore={"NTUSER.DAT*","ntuser.dat*"} $*
  ```
