### PR TITLE
Improvements to shells and general fixes

### DIFF
--- a/Cmder.bat
+++ b/Cmder.bat
@@ -5,7 +5,12 @@ SET CMDER_ROOT=%~dp0
 @if "%CMDER_ROOT:~-1%" == "\" SET CMDER_ROOT=%CMDER_ROOT:~0,-1%
 
 if not exist "%CMDER_ROOT%\config\user_ConEmu.xml" (
-    copy "%CMDER_ROOT%\vendor\ConEmu.xml.default" "%CMDER_ROOT%\config\user_ConEmu.xml"
+    if not exist "%CMDER_ROOT%\config" mkdir "%CMDER_ROOT%\config" 2>nul
+    copy "%CMDER_ROOT%\vendor\ConEmu.xml.default" "%CMDER_ROOT%\config\user_ConEmu.xml" 1>nul
+    if %errorlevel% neq 0 (
+        echo ERROR: CMDER Initialization has Failed
+        exit /b 1
+    )
 )
 
 if exist "%~1" (

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -88,7 +88,7 @@ if ($Compile) {
     Pop-Location
 }
 
-if (-Not $noVendor) {
+if (-not $noVendor) {
     # Check for requirements
     Ensure-Exists $sourcesPath
     Ensure-Executable "7z"
@@ -162,7 +162,7 @@ if (-Not $noVendor) {
     Pop-Location
 }
 
-if (-Not $Compile -Or $noVendor) {
+if (-not $Compile -or $noVendor) {
     Write-Warning "You are not building the full project, Use -Compile without -noVendor"
     Write-Warning "This cannot be a release. Test build only!"
     return

--- a/scripts/update.ps1
+++ b/scripts/update.ps1
@@ -55,7 +55,7 @@ function Match-Filenames {
 
     $position = 0
 
-    if ([String]::IsNullOrEmpty($filename) -Or [String]::IsNullOrEmpty($filenameDownload)) {
+    if ([String]::IsNullOrEmpty($filename) -or [String]::IsNullOrEmpty($filenameDownload)) {
         throw "Either one or both filenames are empty!"
     }
 
@@ -88,15 +88,15 @@ function Fetch-DownloadUrl {
 
     $url = [uri] $urlStr
 
-    if ((-Not $url) -Or ($null -eq $url) -Or ($url -eq '')) {
+    if ((-not $url) -or ($null -eq $url) -or ($url -eq '')) {
         throw "Failed to parse url: $urlStr"
     }
 
-    if (-Not ("http", "https" -Contains $url.Scheme)) {
+    if (-not ("http", "https" -contains $url.Scheme)) {
         throw "unknown source scheme: $($url.Scheme)"
     }
 
-    if (-Not ($url.Host -ilike "*github.com")) {
+    if (-not ($url.Host -ilike "*github.com")) {
         throw "unknown source domain: $($url.Host)"
     }
 
@@ -116,12 +116,12 @@ function Fetch-DownloadUrl {
 
     $charCount = 0
 
-    if (-Not ($info -Is [array])) {
+    if (-not ($info -is [array])) {
         throw "The response received from API server is invalid"
     }
 
     :loop foreach ($i in $info) {
-        if (-Not ($i.assets -Is [array])) {
+        if (-not ($i.assets -is [array])) {
             continue
         }
 
@@ -157,12 +157,12 @@ function Fetch-DownloadUrl {
     }
 
     # Special case for archive downloads of repository
-    if (($null -eq $downloadLinks) -Or (-Not $downloadLinks)) {
-        if ((($p | % { $_.Trim('/') }) -Contains "archive") -And $info[0].tag_name) {
+    if (($null -eq $downloadLinks) -or (-not $downloadLinks)) {
+        if ((($p | ForEach-Object { $_.Trim('/') }) -contains "archive") -and $info[0].tag_name) {
             for ($i = 0; $i -lt $p.Length; $i++) {
                 if ($p[$i].Trim('/') -eq "archive") {
                     $p[$i + 1] = $info[0].tag_name + ".zip"
-                    $downloadLinks = $url.Scheme + "://" + $url.Host + ($p -Join '')
+                    $downloadLinks = $url.Scheme + "://" + $url.Host + ($p -join '')
                     return $downloadLinks
                 }
             }
@@ -188,11 +188,11 @@ function Fetch-DownloadUrl {
 
     $downloadLinks = $temp | Where-Object { (Match-Filenames $url $_ true) -eq $charCount }
 
-    if (($null -eq $downloadLinks) -Or (-Not $downloadLinks)) {
+    if (($null -eq $downloadLinks) -or (-not $downloadLinks)) {
         throw "No suitable download links matched for the url!"
     }
 
-    if (-Not($downloadLinks -is [String])) {
+    if (-not($downloadLinks -is [String])) {
         throw "Found multiple matches for the same url:`n" + $downloadLinks
     }
 
@@ -211,7 +211,7 @@ foreach ($s in $sources) {
 
     $downloadUrl = Fetch-DownloadUrl $s.url
 
-    if (($null -eq $downloadUrl) -Or ($downloadUrl -eq '')) {
+    if (($null -eq $downloadUrl) -or ($downloadUrl -eq '')) {
         Write-Verbose "No new links were found"
         continue
     }
@@ -222,15 +222,15 @@ foreach ($s in $sources) {
 
     $version = ''
 
-    if ( ($url.Segments[-3] -eq "download/") -And ($url.Segments[-2].StartsWith("v")) ) {
+    if (($url.Segments[-3] -eq "download/") -and ($url.Segments[-2].StartsWith("v"))) {
         $version = $url.Segments[-2].TrimStart('v').TrimEnd('/')
     }
 
-    if ( ($url.Segments[-2] -eq "archive/") ) {
+    if (($url.Segments[-2] -eq "archive/")) {
         $version = [System.IO.Path]::GetFileNameWithoutExtension($url.Segments[-1].TrimStart('v').TrimEnd('/'))
     }
 
-    if ( $version -eq '' ) {
+    if ($version -eq '') {
         throw "Unable to extract version from url string"
     }
 
@@ -255,11 +255,11 @@ if ($count -eq 0) {
     return
 }
 
-if ( $Env:APPVEYOR -eq 'True' ) {
+if ($Env:APPVEYOR -eq 'True') {
     Add-AppveyorMessage -Message "Successfully updated $count dependencies." -Category Information
 }
 
-if ( $Env:GITHUB_ACTIONS -eq 'true' ) {
+if ($Env:GITHUB_ACTIONS -eq 'true') {
     Write-Output "::notice title=Task Complete::Successfully updated $count dependencies."
 }
 

--- a/scripts/utils.ps1
+++ b/scripts/utils.ps1
@@ -32,17 +32,19 @@ function Delete-Existing($path) {
 function Extract-Archive($source, $target) {
     Write-Verbose $("Extracting Archive '$cmder_root\vendor\" + $source.replace('/','\') + " to '$cmder_root\vendor\$target'")
     Invoke-Expression "7z x -y -o`"$($target)`" `"$source`"  > `$null"
-    if ($lastexitcode -ne 0) {
+    if ($LastExitCode -ne 0) {
         Write-Error "Extracting of $source failed"
     }
     Remove-Item $source
 }
 
 function Create-Archive($source, $target, $params) {
-    $command = "7z a -xr@`"$source\packignore`" $params `"$target`" `"$source\*`"  > `$null"
+    $command = "7z a -x@`"$source\packignore`" $params `"$target`" `"*`"  > `$null"
     Write-Verbose "Creating Archive from '$source' in '$target' with parameters '$params'"
+    Push-Location $source
     Invoke-Expression $command
-    if ($lastexitcode -ne 0) {
+    Pop-Location
+    if ($LastExitCode -ne 0) {
         Write-Error "Compressing $source failed"
     }
 }
@@ -54,7 +56,7 @@ function Flatten-Directory($name) {
     $moving = "$($name)_moving"
     Rename-Item $name -NewName $moving
     Write-Verbose "Flattening the '$name' directory..."
-    $child = (Get-Childitem $moving)[0] | Resolve-Path
+    $child = (Get-ChildItem $moving)[0] | Resolve-Path
     Move-Item -Path $child -Destination $name
     Remove-Item -Recurse $moving
 }
@@ -78,7 +80,7 @@ function Set-GHVariable {
     Write-Verbose "Setting CI variable $Name to $Value" -Verbose
 
     if ($env:GITHUB_ENV) {
-        echo "$Name=$Value" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+        Write-Output "$Name=$Value" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
     }
 }
 
@@ -130,7 +132,7 @@ function Parse-Changelog($file) {
     [regex]$regex = '^## \[(?<version>[\w\-\.]+)\]\([^\n()]+\)\s+\([^\n()]+\)$';
 
     # Find the first match of the version string which means the latest version
-    $version = Select-String -Path $file -Pattern $regex | Select-Object -First 1 | % { $_.Matches.Groups[1].Value }
+    $version = Select-String -Path $file -Pattern $regex | Select-Object -First 1 | ForEach-Object { $_.Matches.Groups[1].Value }
 
     return $version
 }

--- a/scripts/utils.ps1
+++ b/scripts/utils.ps1
@@ -226,12 +226,12 @@ function Download-File {
 
     $useBitTransfer = $null -ne (Get-Module -Name BitsTransfer -ListAvailable) -and ($PSVersionTable.PSVersion.Major -le 5)
 
-    $File = $File -Replace "/", "\"
+    $File = $File -replace "/", "\"
 
     try {
         if ($useBitTransfer) {
-            Start-BitsTransfer -Source $Url -Destination $File -DisplayName "Downloading $Url to $File"
-            Return
+            Start-BitsTransfer -Source $Url -Destination $File -DisplayName "Downloading '$Url' to $File"
+            return
         }
     }
     catch {

--- a/vendor/bin/cmder_diag.ps1
+++ b/vendor/bin/cmder_diag.ps1
@@ -1,4 +1,4 @@
-if (Test-Path  $env:temp\cmder_diag_ps.log) {
+if (test-path  $env:temp\cmder_diag_ps.log) {
   remove-item $env:temp\cmder_diag_ps.log
 }
 

--- a/vendor/bin/cmder_diag.ps1
+++ b/vendor/bin/cmder_diag.ps1
@@ -1,4 +1,4 @@
-if (test-path  $env:temp\cmder_diag_ps.log) {
+if (Test-Path  $env:temp\cmder_diag_ps.log) {
   remove-item $env:temp\cmder_diag_ps.log
 }
 

--- a/vendor/clink.lua
+++ b/vendor/clink.lua
@@ -28,21 +28,21 @@ end
 
 
 local function get_clean_color()
-    return clean_color or "\x1b[1;37;49m"
+    return clean_color or "\x1b[37;1m" -- Bold, White
 end
 
 
 local function get_dirty_color()
-    return dirty_color or "\x1b[33;3m"
+    return dirty_color or "\x1b[33;3m" -- Italic, Yellow
 end
 
 
 local function get_conflict_color()
-    return conflict_color or "\x1b[31;1m"
+    return conflict_color or "\x1b[31;1m" -- Bold, Red
 end
 
 local function get_unknown_color()
-    return unknown_color or "\x1b[37;1m"
+    return unknown_color or "\x1b[37;1m" -- Bold, White
 end
 
 ---

--- a/vendor/clink.lua
+++ b/vendor/clink.lua
@@ -28,21 +28,21 @@ end
 
 
 local function get_clean_color()
-    return clean_color or "\x1b[37;1m" -- Bold, White
+    return clean_color or "\x1b[37;1m" -- White, Bold
 end
 
 
 local function get_dirty_color()
-    return dirty_color or "\x1b[33;3m" -- Italic, Yellow
+    return dirty_color or "\x1b[33;3m" -- Yellow, Italic
 end
 
 
 local function get_conflict_color()
-    return conflict_color or "\x1b[31;1m" -- Bold, Red
+    return conflict_color or "\x1b[31;1m" -- Red, Bold
 end
 
 local function get_unknown_color()
-    return unknown_color or "\x1b[37;1m" -- Bold, White
+    return unknown_color or "\x1b[37;1m" -- White, Bold
 end
 
 ---

--- a/vendor/cmder_prompt_config.lua.default
+++ b/vendor/cmder_prompt_config.lua.default
@@ -45,7 +45,9 @@ prompt_overrideSvnStatusOptIn = false
 
 -- Prompt Attributes
 --
--- Colors
+-- Colors: https://github.com/cmderdev/cmder/wiki/Customization#list-of-colors
+-- Effects: https://github.com/cmderdev/cmder/wiki/Customization#list-of-effects
+--
 -- Green:      "\x1b[1;33;49m"
 -- Yellow:     "\x1b[1;32;49m"
 -- Light Grey: "\x1b[1;30;49m"
@@ -54,7 +56,7 @@ prompt_overrideSvnStatusOptIn = false
 uah_color = "\x1b[1;33;49m" -- Green = uah = [user]@[hostname]
 cwd_color = "\x1b[1;32;49m" -- Yellow cwd = Current Working Directory
 lamb_color = "\x1b[1;30;49m" -- Light Grey = Lambda Color
-clean_color = "\x1b[1;37;49m"
-dirty_color = "\x1b[33;3m"
-conflict_color = "\x1b[31;1m"
+clean_color = "\x1b[37;1m"
+dirty_color = "\x1b[33;3m" -- Yellow, Italic
+conflict_color = "\x1b[31;1m" -- Red, Bold
 unknown_color = "\x1b[37;1m" -- White = No VCS Status Branch Color

--- a/vendor/lib/lib_base.cmd
+++ b/vendor/lib/lib_base.cmd
@@ -68,13 +68,9 @@ exit /b
     set CMDER_SHELL=%~n1
     if not defined CMDER_CLINK (
         set CMDER_CLINK=1
-        if "%CMDER_SHELL%" equ "tcc" set CMDER_CLINK=0
-        if "%CMDER_SHELL%" equ "tccle" set CMDER_CLINK=0
     )
     if not defined CMDER_ALIASES (
         set CMDER_ALIASES=1
-        if "%CMDER_SHELL%" equ "tcc" set CMDER_ALIASES=0
-        if "%CMDER_SHELL%" equ "tccle" set CMDER_ALIASES=0
     )
     exit /b
 

--- a/vendor/lib/lib_console.cmd
+++ b/vendor/lib/lib_console.cmd
@@ -7,9 +7,10 @@ set ESC=
 :: Much faster than using "%lib_console% debug_output ..." etc.
 set print_debug=if %debug_output% gtr 0 %lib_console% debug_output
 set print_verbose=if %verbose_output% gtr 0 %lib_console% verbose_output
+set print_warning=if %verbose_output% gtr 0 %lib_console% show_warning
 set print_error=%lib_console% show_error
 
-if "%fast_init%" == "1" exit /b
+if %fast_init% gtr %verbose_output% if %fast_init% gtr %debug_output% exit /b
 
 if "%~1" == "/h" (
     %lib_base% help "%~0"
@@ -82,4 +83,25 @@ exit /b
 :::-------------------------------------------------------------------------------
 
     echo %ESC%[91;1mERROR:%ESC%[0m %~1
+    exit /b
+
+:show_warning
+:::===============================================================================
+:::show_warning - Output a warning message to the console.
+:::.
+:::include:
+:::.
+:::  call "$0"
+:::.
+:::usage:
+:::.
+:::  %lib_console% show_warning "[message]"
+:::.
+:::required:
+:::.
+:::  [message] <in> Message text to display.
+:::.
+:::-------------------------------------------------------------------------------
+
+    echo %ESC%[93;1mWARNING:%ESC%[0m %~1
     exit /b

--- a/vendor/lib/lib_git.cmd
+++ b/vendor/lib/lib_git.cmd
@@ -101,9 +101,9 @@ exit /b
 
     REM endlocal & set "%~1_MAJOR=!%~1_MAJOR!" & set "%~1_MINOR=!%~1_MINOR!" & set "%~1_PATCH=!%~1_PATCH!" & set "%~1_BUILD=!%~1_BUILD!"
     if "%~1" == "VENDORED" (
-      endlocal & set "%~1_MAJOR=%VENDORED_MAJOR%" & set "%~1_MINOR=%VENDORED_MINOR%" & set "%~1_PATCH=%VENDORED_PATCH%" & set "%~1_BUILD=%VENDORED_BUILD%"
+        endlocal & set "%~1_MAJOR=%VENDORED_MAJOR%" & set "%~1_MINOR=%VENDORED_MINOR%" & set "%~1_PATCH=%VENDORED_PATCH%" & set "%~1_BUILD=%VENDORED_BUILD%"
     ) else (
-      endlocal & set "%~1_MAJOR=%USER_MAJOR%" & set "%~1_MINOR=%USER_MINOR%" & set "%~1_PATCH=%USER_PATCH%" & set "%~1_BUILD=%USER_BUILD%"
+        endlocal & set "%~1_MAJOR=%USER_MAJOR%" & set "%~1_MINOR=%USER_MINOR%" & set "%~1_PATCH=%USER_PATCH%" & set "%~1_BUILD=%USER_BUILD%"
     )
 
     exit /b
@@ -136,9 +136,9 @@ exit /b
     :: ... and maybe display it, for debugging purposes.
     REM %print_debug% :validate_version "Found Git Version for %~1: !%~1_MAJOR!.!%~1_MINOR!.!%~1_PATCH!.!%~1_BUILD!"
     if "%~1" == "VENDORED" (
-      %print_debug% :validate_version "Found Git Version for %~1: %VENDORED_MAJOR%.%VENDORED_MINOR%.%VENDORED_PATCH%.%VENDORED_BUILD%"
+        %print_debug% :validate_version "Found Git Version for %~1: %VENDORED_MAJOR%.%VENDORED_MINOR%.%VENDORED_PATCH%.%VENDORED_BUILD%"
     ) else (
-      %print_debug% :validate_version "Found Git Version for %~1: %USER_MAJOR%.%USER_MINOR%.%USER_PATCH%.%USER_BUILD%"
+        %print_debug% :validate_version "Found Git Version for %~1: %USER_MAJOR%.%USER_MINOR%.%USER_PATCH%.%USER_BUILD%"
     )
     exit /b
 

--- a/vendor/lib/lib_path.cmd
+++ b/vendor/lib/lib_path.cmd
@@ -60,14 +60,14 @@ exit /b
     )
 
     if "%fast_init%" == "1" (
-      if "%position%" == "append" (
-        set "PATH=%PATH%;%add_to_path%"
-      ) else (
-        set "PATH=%add_to_path%;%PATH%"
-      )
-      goto :end_enhance_path
+        if "%position%" == "append" (
+            set "PATH=%PATH%;%add_to_path%"
+        ) else (
+            set "PATH=%add_to_path%;%PATH%"
+        )
+        goto :end_enhance_path
     ) else if "add_to_path" equ "" (
-      goto :end_enhance_path
+        goto :end_enhance_path
     )
 
     set found=0
@@ -78,23 +78,23 @@ exit /b
 
     setlocal enabledelayedexpansion
     if "!found!" == "0" (
-      echo "!path!"|!WINDIR!\System32\findstr >nul /I /R /C:";!find_query!;"
-      call :set_found
+        echo "!path!"|!WINDIR!\System32\findstr >nul /I /R /C:";!find_query!;"
+        call :set_found
     )
     %print_debug%  :enhance_path "Env Var INSIDE PATH !find_query! - found=!found!"
 
     if /i "!position!" == "append" (
-      if "!found!" == "0" (
-        echo "!path!"|!WINDIR!\System32\findstr >nul /I /R /C:";!find_query!\"$"
-        call :set_found
-      )
-      %print_debug%  :enhance_path "Env Var END PATH !find_query! - found=!found!"
+        if "!found!" == "0" (
+            echo "!path!"|!WINDIR!\System32\findstr >nul /I /R /C:";!find_query!\"$"
+            call :set_found
+        )
+        %print_debug%  :enhance_path "Env Var END PATH !find_query! - found=!found!"
     ) else (
-      if "!found!" == "0" (
-        echo "!path!"|!WINDIR!\System32\findstr >nul /I /R /C:"^\"!find_query!;"
-        call :set_found
-      )
-      %print_debug%  :enhance_path "Env Var BEGIN PATH !find_query! - found=!found!"
+        if "!found!" == "0" (
+            echo "!path!"|!WINDIR!\System32\findstr >nul /I /R /C:"^\"!find_query!;"
+            call :set_found
+        )
+        %print_debug%  :enhance_path "Env Var BEGIN PATH !find_query! - found=!found!"
     )
     endlocal & set found=%found%
 
@@ -121,24 +121,24 @@ exit /b
     exit /b
 
     :toolong
-      echo "%OLD_PATH%">"%temp%\cmder_lib_pathA"
-      echo "%PATH%">"%temp%\cmder_lib_pathB"
-      fc /b "%temp%\cmder_lib_pathA" "%temp%\cmder_lib_pathB" 2>nul 1>nul
-      if errorlevel 1 ( del "%temp%\cmder_lib_pathA" & del "%temp%\cmder_lib_pathB" & goto :changed )
-      del "%temp%\cmder_lib_pathA" & del "%temp%\cmder_lib_pathB"
-      exit /b
+        echo "%OLD_PATH%">"%temp%\cmder_lib_pathA"
+        echo "%PATH%">"%temp%\cmder_lib_pathB"
+        fc /b "%temp%\cmder_lib_pathA" "%temp%\cmder_lib_pathB" 2>nul 1>nul
+        if errorlevel 1 ( del "%temp%\cmder_lib_pathA" & del "%temp%\cmder_lib_pathB" & goto :changed )
+        del "%temp%\cmder_lib_pathA" & del "%temp%\cmder_lib_pathB"
+        exit /b
 
     :changed
-      %print_debug%  :enhance_path "END Env Var - PATH=%path%"
-      %print_debug%  :enhance_path "Env Var %find_query% - found=%found%"
-      exit /b
+        %print_debug%  :enhance_path "END Env Var - PATH=%path%"
+        %print_debug%  :enhance_path "Env Var %find_query% - found=%found%"
+        exit /b
 
     exit /b
 
 
 :set_found
     if "%ERRORLEVEL%" == "0" (
-      set found=1
+        set found=1
     )
 
     exit /b
@@ -202,7 +202,7 @@ exit /b
 
     set "PATH=%PATH:;;=;%"
     if "%fast_init%" == "1" (
-      exit /b
+        exit /b
     )
 
     %print_debug%  :enhance_path_recursive "Env Var - add_path=%add_to_path%"

--- a/vendor/lib/lib_profile.cmd
+++ b/vendor/lib/lib_profile.cmd
@@ -32,15 +32,15 @@ exit /b
 :::  path       <out> Sets the path env variable if required.
 :::-------------------------------------------------------------------------------
 
-  if not exist "%~1" (
-    mkdir "%~1"
-  )
+    if not exist "%~1" (
+        mkdir "%~1"
+    )
 
-  pushd "%~1"
-  for /f "usebackq" %%x in ( `dir /b *.bat *.cmd 2^>nul` ) do (
-    %print_verbose% "Calling '%~1\%%x'..."
-    call "%~1\%%x"
-  )
-  popd
-  exit /b
+    pushd "%~1"
+    for /f "usebackq" %%x in ( `dir /b *.bat *.cmd 2^>nul` ) do (
+        %print_verbose% "Calling '%~1\%%x'..."
+        call "%~1\%%x"
+    )
+    popd
+    exit /b
 

--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -196,16 +196,16 @@ if ( $(Get-Command prompt).Definition -match 'PS \$\(\$executionContext.SessionS
     #>
     [ScriptBlock]$Prompt = {
         $lastSUCCESS = $?
-        $realLASTEXITCODE = $LASTEXITCODE
+        $realLastExitCode = $LastExitCode
         $host.UI.RawUI.WindowTitle = Microsoft.PowerShell.Management\Split-Path $pwd.ProviderPath -Leaf
         Microsoft.PowerShell.Utility\Write-Host -NoNewline "$([char]0x200B)`r$([char]0x1B)[K"
-        if ($lastSUCCESS -or ($LASTEXITCODE -ne 0)) {
+        if ($lastSUCCESS -or ($LastExitCode -ne 0)) {
             Microsoft.PowerShell.Utility\Write-Host
         }
         PrePrompt | Microsoft.PowerShell.Utility\Write-Host -NoNewline
         CmderPrompt
         PostPrompt | Microsoft.PowerShell.Utility\Write-Host -NoNewline
-        $global:LASTEXITCODE = $realLASTEXITCODE
+        $global:LastExitCode = $realLastExitCode
         return " "
     }
 

--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -1,6 +1,6 @@
 ﻿# Init Script for PowerShell
 # Created as part of Cmder project
-# This file must be saved using UTF-8 with BOM encoding for prompt to work correctly.
+# NOTE: This file must be saved using UTF-8 with BOM encoding for prompt symbol to work correctly.
 
 # !!! THIS FILE IS OVERWRITTEN WHEN CMDER IS UPDATED
 # !!! Use "%CMDER_ROOT%\config\user_profile.ps1" to add your own startup commands
@@ -13,7 +13,7 @@ if (!$PSScriptRoot) {
 }
 
 if ($ENV:CMDER_USER_CONFIG) {
-    # Write-Host "CMDER IS ALSO USING INDIVIDUAL USER CONFIG FROM '$ENV:CMDER_USER_CONFIG'!"
+    Write-Verbose "CMDER IS ALSO USING INDIVIDUAL USER CONFIG FROM '$ENV:CMDER_USER_CONFIG'!"
 }
 
 # We do this for Powershell as Admin Sessions because CMDER_ROOT is not being set.
@@ -43,18 +43,18 @@ if(-not $moduleInstallerAvailable -and -not $env:PSModulePath.Contains($CmderMod
 }
 
 $gitVersionVendor = (readVersion -gitPath "$ENV:CMDER_ROOT\vendor\git-for-windows\cmd")
-# Write-Host "GIT VENDOR: ${gitVersionVendor}"
+Write-Debug "GIT VENDOR: ${gitVersionVendor}"
 
 # Get user installed Git Version[s] and Compare with vendored if found.
 foreach ($git in (Get-Command -ErrorAction SilentlyContinue 'git')) {
-    # Write-Host "GIT PATH: " + $git.Path
+    Write-Debug "GIT PATH: {$git.Path}"
     $gitDir = Split-Path -Path $git.Path
     $gitDir = isGitShim -gitPath $gitDir
     $gitVersionUser = (readVersion -gitPath $gitDir)
-    # Write-Host "GIT USER: ${gitVersionUser}"
+    Write-Debug "GIT USER: ${gitVersionUser}"
 
     $useGitVersion = compare_git_versions -userVersion $gitVersionUser -vendorVersion $gitVersionVendor
-    # Write-Host "Using GIT Version: ${useGitVersion}"
+    Write-Debug "Using Git Version: ${useGitVersion}"
 
     # Use user installed Git
     if ($null -eq $gitPathUser) {
@@ -66,7 +66,7 @@ foreach ($git in (Get-Command -ErrorAction SilentlyContinue 'git')) {
     }
 
     if ($useGitVersion -eq $gitVersionUser) {
-        # Write-Host "Using GIT Dir: ${gitDir}"
+        Write-Debug "Using Git Dir: ${gitDir}"
         $ENV:GIT_INSTALL_ROOT = $gitPathUser
         $ENV:GIT_INSTALL_TYPE = 'USER'
         break
@@ -79,10 +79,10 @@ if ($null -eq $ENV:GIT_INSTALL_ROOT -and $null -ne $gitVersionVendor) {
     $ENV:GIT_INSTALL_TYPE = 'VENDOR'
 }
 
-# Write-Host "GIT_INSTALL_ROOT: ${ENV:GIT_INSTALL_ROOT}"
-# Write-Host "GIT_INSTALL_TYPE: ${ENV:GIT_INSTALL_TYPE}"
+Write-Debug "GIT_INSTALL_ROOT: ${ENV:GIT_INSTALL_ROOT}"
+Write-Debug "GIT_INSTALL_TYPE: ${ENV:GIT_INSTALL_TYPE}"
 
-if (-Not ($null -eq $ENV:GIT_INSTALL_ROOT)) {
+if ($null -ne $ENV:GIT_INSTALL_ROOT) {
     $env:Path = Configure-Git -gitRoot "$ENV:GIT_INSTALL_ROOT" -gitType $ENV:GIT_INSTALL_TYPE -gitPathUser $gitPathUser
 }
 
@@ -95,21 +95,20 @@ if (Get-Module PSReadline -ErrorAction "SilentlyContinue") {
 }
 
 # Pre-assign default prompt hooks so the first run of cmder gets a working prompt.
-$env:gitLoaded = $false
+$env:gitLoaded = $null
 [ScriptBlock]$PrePrompt = {}
 [ScriptBlock]$PostPrompt = {}
 [ScriptBlock]$CmderPrompt = {
+    # Check if we're currently running under Admin privileges.
     $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
     $principal = [Security.Principal.WindowsPrincipal] $identity
     $adminRole = [Security.Principal.WindowsBuiltInRole]::Administrator
     $color = "White"
     if ($principal.IsInRole($adminRole)) { $color = "Red" }
     $Host.UI.RawUI.ForegroundColor = "White"
-    Microsoft.PowerShell.Utility\Write-Host -NoNewline "PS " -ForegroundColor $color
+    Microsoft.PowerShell.Utility\Write-Host "PS " -NoNewline -ForegroundColor $color
     Microsoft.PowerShell.Utility\Write-Host $pwd.ProviderPath -NoNewLine -ForegroundColor Green
-    if (Get-Command git -ErrorAction SilentlyContinue) {
-        checkGit($pwd.ProviderPath)
-    }
+    checkGit($pwd.ProviderPath)
     Microsoft.PowerShell.Utility\Write-Host "`nλ" -NoNewLine -ForegroundColor "DarkGray"
 }
 
@@ -118,33 +117,31 @@ $env:Path = "$Env:CMDER_ROOT\bin;$Env:CMDER_ROOT\vendor\bin;$env:Path;$Env:CMDER
 
 # Drop *.ps1 files into "$ENV:CMDER_ROOT\config\profile.d"
 # to source them at startup.
-if (-Not (Test-Path -PathType container "$ENV:CMDER_ROOT\config\profile.d")) {
+if (-not (Test-Path -PathType container "$ENV:CMDER_ROOT\config\profile.d")) {
     New-Item -ItemType Directory -Path "$ENV:CMDER_ROOT\config\profile.d"
 }
 
 Push-Location $ENV:CMDER_ROOT\config\profile.d
 foreach ($x in Get-ChildItem *.psm1) {
-    # Write-Host Write-Host Sourcing $x
+    Write-Verbose Write-Host Sourcing $x
     Import-Module $x
 }
-
 foreach ($x in Get-ChildItem *.ps1) {
-    # Write-Host Write-Host Sourcing $x
+    Write-Verbose Write-Host Sourcing $x
     . $x
 }
 Pop-Location
 
 # Drop *.ps1 files into "$ENV:CMDER_USER_CONFIG\config\profile.d"
 # to source them at startup.  Requires using cmder.exe /C [cmder_user_root_path] argument
-if ($ENV:CMDER_USER_CONFIG -ne "" -And (Test-Path "$ENV:CMDER_USER_CONFIG\profile.d")) {
+if ($ENV:CMDER_USER_CONFIG -ne "" -and (Test-Path "$ENV:CMDER_USER_CONFIG\profile.d")) {
     Push-Location $ENV:CMDER_USER_CONFIG\profile.d
     foreach ($x in Get-ChildItem *.psm1) {
-        # Write-Host Write-Host Sourcing $x
+        Write-Verbose Write-Host Sourcing $x
         Import-Module $x
     }
-
     foreach ($x in Get-ChildItem *.ps1) {
-        # Write-Host Write-Host Sourcing $x
+        Write-Verbose Write-Host Sourcing $x
         . $x
     }
     Pop-Location
@@ -175,8 +172,10 @@ if ($ENV:CMDER_USER_CONFIG) {
     }
 }
 
-if (-Not (Test-Path $CmderUserProfilePath)) {
-    Write-Host -BackgroundColor DarkGreen -ForegroundColor White "First Run: Creating user startup file: $CmderUserProfilePath"
+if (-not (Test-Path $CmderUserProfilePath)) {
+    $CmderUserProfilePath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($CmderUserProfilePath)
+    Write-Host -NoNewline "`r"
+    Write-Host -BackgroundColor Green -ForegroundColor Black "First Run: Creating user startup file: $CmderUserProfilePath"
     Copy-Item "$env:CMDER_ROOT\vendor\user_profile.ps1.default" -Destination $CmderUserProfilePath
 }
 
@@ -200,7 +199,7 @@ if ( $(Get-Command prompt).Definition -match 'PS \$\(\$executionContext.SessionS
         $realLASTEXITCODE = $LASTEXITCODE
         $host.UI.RawUI.WindowTitle = Microsoft.PowerShell.Management\Split-Path $pwd.ProviderPath -Leaf
         Microsoft.PowerShell.Utility\Write-Host -NoNewline "$([char]0x200B)`r$([char]0x1B)[K"
-        if ($lastSUCCESS -Or ($LASTEXITCODE -ne 0)) {
+        if ($lastSUCCESS -or ($LASTEXITCODE -ne 0)) {
             Microsoft.PowerShell.Utility\Write-Host
         }
         PrePrompt | Microsoft.PowerShell.Utility\Write-Host -NoNewline
@@ -209,7 +208,6 @@ if ( $(Get-Command prompt).Definition -match 'PS \$\(\$executionContext.SessionS
         $global:LASTEXITCODE = $realLASTEXITCODE
         return " "
     }
-
 
     # Once Created these code blocks cannot be overwritten
     # if (-not $(Get-Command PrePrompt).Options   -match 'Constant') {Set-Item -Path function:\PrePrompt   -Value $PrePrompt   -Options Constant}

--- a/vendor/psmodules/Cmder.ps1
+++ b/vendor/psmodules/Cmder.ps1
@@ -1,7 +1,7 @@
 function readVersion($gitPath) {
     $gitExecutable = "${gitPath}\git.exe"
 
-    if (!(test-path "$gitExecutable")) {
+    if (-not (Test-Path "$gitExecutable")) {
         return $null
     }
 
@@ -20,44 +20,44 @@ function readVersion($gitPath) {
 function isGitShim($gitPath) {
     # check if there's shim - and if yes follow the path
 
-    if (test-path "${gitPath}\git.shim") {
-      $shim = (get-content "${gitPath}\git.shim")
-      ($trash, $gitPath) = $shim.replace(' ','').split('=')
+    if (Test-Path "${gitPath}\git.shim") {
+        $shim = (get-content "${gitPath}\git.shim")
+        ($trash, $gitPath) = $shim.replace(' ', '').split('=')
 
-      $gitPath=$gitPath.replace('\git.exe','')
+        $gitPath = $gitPath.replace('\git.exe', '')
     }
 
     return $gitPath.toString()
 }
 
 function compareVersions($userVersion, $vendorVersion) {
-    if (-not($userVersion -eq $null)) {
+    if ($null -ne $userVersion) {
         ($userMajor, $userMinor, $userPatch, $userBuild) = $userVersion.split('.', 4)
     } else {
         return -1
     }
 
-    if (-not($vendorVersion -eq $null)) {
+    if ($null -ne $vendorVersion) {
         ($vendorMajor, $vendorMinor, $vendorPatch, $vendorBuild) = $vendorVersion.split('.', 4)
     } else {
         return 1
     }
 
-    if (($userMajor -eq $vendorMajor) -and  ($userMinor -eq $vendorMinor) -and  ($userPatch -eq $vendorPatch) -and  ($userBuild -eq $vendorBuild)) {
+    if (($userMajor -eq $vendorMajor) -and ($userMinor -eq $vendorMinor) -and ($userPatch -eq $vendorPatch) -and ($userBuild -eq $vendorBuild)) {
         return 1
     }
 
-    if ($userMajor -gt $vendorMajor) {return 1}
-    if ($userMajor -lt $vendorMajor) {return -1}
+    if ($userMajor -gt $vendorMajor) { return 1 }
+    if ($userMajor -lt $vendorMajor) { return -1 }
 
-    if ($userMinor -gt $vendorMinor) {return 1}
-    if ($userMinor -lt $vendorMinor) {return -1}
+    if ($userMinor -gt $vendorMinor) { return 1 }
+    if ($userMinor -lt $vendorMinor) { return -1 }
 
-    if ($userPatch -gt $vendorPatch) {return 1}
-    if ($userPatch -lt $vendorPatch) {return -1}
+    if ($userPatch -gt $vendorPatch) { return 1 }
+    if ($userPatch -lt $vendorPatch) { return -1 }
 
-    if ($userBuild -gt $vendorBuild) {return 1}
-    if ($userBuild -lt $vendorBuild) {return -1}
+    if ($userBuild -gt $vendorBuild) { return 1 }
+    if ($userBuild -lt $vendorBuild) { return -1 }
 
     return 0
 }
@@ -65,45 +65,48 @@ function compareVersions($userVersion, $vendorVersion) {
 function compare_git_versions($userVersion, $vendorVersion) {
     $result = compareVersions -userVersion $userVersion -vendorVersion $vendorVersion
 
-    # write-host "Compare Versions Result: ${result}"
+    Write-Debug "Compare Versions Result: ${result}"
     if ($result -ge 0) {
         return $userVersion
-    } else {
+    }
+    else {
         return $vendorVersion
     }
 }
 
-function Configure-Git($gitRoot, $gitType, $gitPathUser){
+function Configure-Git($gitRoot, $gitType, $gitPathUser) {
     # Proposed Behavior
 
-    # Modify the path if we are using VENDORED Git do nothing if using USER Git.
-    # If User Git is installed but older match its path config adding paths
+    # Modify the path if we are using VENDORED Git, do nothing if using USER Git.
+    # If User Git is installed but is older, match its path config adding paths
     # in the same path positions allowing a user to configure Cmder Git path
     # using locally installed Git Path Config.
     if ($gitType -eq 'VENDOR') {
         # If User Git is installed replace its path config with Newer Vendored Git Path
-        if ($gitPathUser -ne '' -and $gitPathUser -ne $null) {
-            # write-host "Cmder 'profile.ps1': Replacing older user Git path '$gitPathUser' with newer vendored Git path '$gitRoot' in the system path..."
+        if (($null -ne $gitPathUser) -and ($gitPathUser -ne '')) {
+            Write-Verbose "Cmder 'profile.ps1': Replacing older user Git path '$gitPathUser' with newer vendored Git path '$gitRoot' in the system path..."
 
             $newPath = ($env:path -ireplace [regex]::Escape($gitPathUser), $gitRoot)
-        } else {
-            if (!($env:Path -match [regex]::Escape("$gitRoot\cmd"))) {
-                # write-host "Adding $gitRoot\cmd to the path"
+        }
+        else {
+            if (-not ($env:Path -match [regex]::Escape("$gitRoot\cmd"))) {
+                Write-Debug "Adding $gitRoot\cmd to the path"
                 $newPath = $($gitRoot + "\cmd" + ";" + $env:Path)
             }
 
             # Add "$gitRoot\mingw[32|64]\bin" to the path if exists and not done already
-            if ((test-path "$gitRoot\mingw32\bin") -and -not ($env:path -match [regex]::Escape("$gitRoot\mingw32\bin"))) {
-                # write-host "Adding $gitRoot\mingw32\bin to the path"
+            if ((Test-Path "$gitRoot\mingw32\bin") -and -not ($env:path -match [regex]::Escape("$gitRoot\mingw32\bin"))) {
+                Write-Debug "Adding $gitRoot\mingw32\bin to the path"
                 $newPath = "$newPath;$gitRoot\mingw32\bin"
-            } elseif ((test-path "$gitRoot\mingw64\bin") -and -not ($env:path -match [regex]::Escape("$gitRoot\mingw64\bin"))) {
-                # write-host "Adding $gitRoot\mingw64\bin to the path"
+            }
+            elseif ((Test-Path "$gitRoot\mingw64\bin") -and -not ($env:path -match [regex]::Escape("$gitRoot\mingw64\bin"))) {
+                Write-Debug "Adding $gitRoot\mingw64\bin to the path"
                 $newPath = "$newPath;$gitRoot\mingw64\bin"
             }
 
             # Add "$gitRoot\usr\bin" to the path if exists and not done already
-            if ((test-path "$gitRoot\usr\bin") -and -not ($env:path -match [regex]::Escape("$gitRoot\usr\bin"))) {
-                # write-host "Adding $gitRoot\usr\bin to the path"
+            if ((Test-Path "$gitRoot\usr\bin") -and -not ($env:path -match [regex]::Escape("$gitRoot\usr\bin"))) {
+                Write-Debug "Adding $gitRoot\usr\bin to the path"
                 $newPath = "$newPath;$gitRoot\usr\bin"
             }
         }
@@ -114,53 +117,59 @@ function Configure-Git($gitRoot, $gitType, $gitPathUser){
     return $env:path
 }
 
-function Import-Git(){
+function Import-Git() {
     $GitModule = Get-Module -Name Posh-Git -ListAvailable
-    if($GitModule | select version | where version -le ([version]"0.6.1.20160330")){
+    if ($GitModule | Select-Object version | Where-Object version -le ([version]"0.6.1.20160330")) {
         Import-Module Posh-Git > $null
     }
-    if($GitModule | select version | where version -ge ([version]"1.0.0")){
+    if ($GitModule | Select-Object version | Where-Object version -ge ([version]"1.0.0")) {
         Import-Module Posh-Git > $null
         $GitPromptSettings.AnsiConsole = $false
     }
-    if(-not ($GitModule) ) {
-        Write-Warning "Missing git support, install posh-git with 'Install-Module posh-git' and restart cmder."
+    if (-not $GitModule) {
+        Write-Host -NoNewline "`r`n"
+        Write-Warning "Missing git support, install posh-git with 'Install-Module posh-git' and restart Cmder."
+        Write-Host -NoNewline "`r$([char]0x1B)[A"
+        return $false
     }
-    # Make sure we only run once by alawys returning true
+    # Make sure we only run once by always returning true
     return $true
 }
 
 function checkGit($Path) {
-    if (Test-Path -Path (Join-Path $Path '.git') ) {
-      if($env:gitLoaded -eq 'false') {
-        $env:gitLoaded = Import-Git
-      }
-
-      if (getGitStatusSetting -eq $true) {
-        Write-VcsStatus
-      } else {
+    if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+        return
+    }
+    if (-not (Test-Path -Path (Join-Path $Path '.git'))) {
+        $SplitPath = Split-Path $path
+        if ($SplitPath) { checkGit($SplitPath) }
+        return
+    }
+    if (getGitStatusSetting -eq $true) {
+        if ($null -eq $env:gitLoaded) {
+            $env:gitLoaded = Import-Git
+        }
+        if ($env:gitLoaded -eq $true) {
+            Write-VcsStatus
+        }
+    }
+    else {
         $headContent = Get-Content (Join-Path $Path '.git/HEAD')
         if ($headContent -like "ref: refs/heads/*") {
             $branchName = $headContent.Substring(16)
-        } else {
+        }
+        else {
             $branchName = "HEAD detached at $($headContent.Substring(0, 7))"
         }
         Write-Host " [$branchName]" -NoNewline -ForegroundColor White
-      }
-
-      return
-    }
-    $SplitPath = split-path $path
-    if ($SplitPath) {
-        checkGit($SplitPath)
     }
 }
 
 function getGitStatusSetting() {
-    $gitStatus = (git --no-pager config -l) | out-string
+    $gitStatus = (git --no-pager config -l) | Out-String
 
-    ForEach ($line in $($gitStatus -split "`r`n")) {
-        if ($line -match 'cmder.status=false' -or $line -match 'cmder.psstatus=false') {
+    foreach ($line in $($gitStatus -split "`r`n")) {
+        if (($line -match 'cmder.status=false') -or ($line -match 'cmder.psstatus=false')) {
             return $false
         }
     }

--- a/vendor/psmodules/PsGet/PsGet.psm1
+++ b/vendor/psmodules/PsGet/PsGet.psm1
@@ -1818,7 +1818,7 @@ function Expand-ZipModule {
 
         # Check if powershell v3+ and .net v4.5 is available
         $netFailed = $true
-        if ( $PSVersionTable.PSVersion.Major -ge 3 -and (Get-ChildItem -Path 'HKLM:\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4' -Recurse | Get-ItemProperty -Name Version | Where-Object { $_.Version -like '4.5*' -Or $_.Version -ge '4.5' }) ) {
+        if ( $PSVersionTable.PSVersion.Major -ge 3 -and (Get-ChildItem -Path 'HKLM:\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4' -Recurse | Get-ItemProperty -Name Version | Where-Object { $_.Version -like '4.5*' -or $_.Version -ge '4.5' }) ) {
             Write-Debug 'Attempting unzip using the .NET Framework...'
 
             try {


### PR DESCRIPTION
### Description
- Fixed a bug where unintended files were being excluded in built packages (regression: https://github.com/cmderdev/cmder/commit/4b8d669d014274fa8244f0f7ce889b677af06463, closes #2771)
- Improved general coding style formatting to be more concise, and use consistent indentation
- Added documentation in lua configuration files
- Fixed a bug where fast mode would permanently disable console output (https://github.com/cmderdev/cmder/pull/2430#issuecomment-1304561703)
- Detect unsupported clink architecture (e.g. ARM/ARM64)
- Fallback to plain Cmd.exe prompt in Cmder when Clink is disabled
- Improved PowerShell first startup messages
  - Fixed a bug where dark green background would bleed into the next lines
  - Display the warning message when posh is not installed in a new line rather in place of where git status is expected
- Avoid using aliases for commands in PowerShell
