### PR TITLE
Added Context Menu with flexible ConEmu params

### DIFF
--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -527,15 +527,29 @@ void RegisterShellMenu(std::wstring opt, wchar_t* keyBaseName, std::wstring cfgR
 	else {
 		swprintf_s(baseCommandStr, L"\"%s\" /single", exePath);
 	}
+	// /x for ConEmu Extra Argument. Adds lots of possibilitites
 
+	// `"-Dir \`"%V% \`" is that passed argument where directory is properly escaped
+	// NOTE:
+	// Needs an additional space after %V% due to how windows handles files in
+	// context menu. If the current dir is `C:\` and someone opens cmder from
+	// there by shift + right click, the command becomes: `..."... \"C:\ \" ..."`
+	// Interprets to "C:\ ", which is valid
+	// otherwise, the command becomes `..."... \"C:\\" ..."`
+	// Interprets to "C:\"(string close), which is invalid
+
+	// -reuse has benifits of reusing the previous instance 
+
+	// -run will run preconfigured env, I've chosen {cmd::Cmder}
+	const wchar_t conEmuCommands[] = L"/x \"-Dir \\\"%%V%% \\\" -reuse -run {cmd::Cmder}\"";
 	if (cfgRoot.length() == 0) // '/c [path]' was NOT specified
 	{
-		swprintf_s(commandStr, L"%s \"%%V\"", baseCommandStr);
+		swprintf_s(commandStr, L"%s %ls", baseCommandStr, conEmuCommands);
 	}
 	else {
 		std::copy(cfgRoot.begin(), cfgRoot.end(), userConfigDirPath);
 		userConfigDirPath[cfgRoot.length()] = 0;
-		swprintf_s(commandStr, L"%s /c \"%s\" \"%%V\"", baseCommandStr, userConfigDirPath);
+		swprintf_s(commandStr, L"%s /c \"%s\" %ls", baseCommandStr, userConfigDirPath, conEmuCommands);
 	}
 
 	// Now that we have `commandStr`, it's OK to change `exePath`...

--- a/scripts/utils.ps1
+++ b/scripts/utils.ps1
@@ -172,28 +172,28 @@ function Register-Cmder() {
         # Text for the context menu item.
         $MenuText = "Cmder Here"
 
-        , # Defaults to the current cmder directory when run from cmder.
+        # Defaults to the current cmder directory when run from cmder.
         $PathToExe = (Join-Path $env:CMDER_ROOT "cmder.exe")
 
-        , # Commands the context menu will execute
+        # Commands the context menu will execute
 
-        , # /x for ConEmu Extra Argument. Adds lots of possibilitites
+        # /x for ConEmu Extra Argument. Adds lots of possibilitites
 
-        , # `"-Dir \`"%V% \`" is that passed argument where directory is properly escaped
-        , # NOTE:
-        , # Needs an additional space after %V% due to how windows handles files in
-        , # context menu. If the current dir is `C:\` and someone opens cmder from
-        , # there by shift + right click, the command becomes: `..."... \"C:\ \" ..."`
-        , # Interprets to "C:\ ", which is valid
-        , # otherwise, the command becomes `..."... \"C:\\" ..."`
-        , # Interprets to "C:\"(string close), which is invalid
+        # `"-Dir \`"%V% \`" is that passed argument where directory is properly escaped
+        # NOTE:
+        # Needs an additional space after %V% due to how windows handles files in
+        # context menu. If the current dir is `C:\` and someone opens cmder from
+        # there by shift + right click, the command becomes: `..."... \"C:\ \" ..."`
+        # Interprets to "C:\ ", which is valid
+        # otherwise, the command becomes `..."... \"C:\\" ..."`
+        # Interprets to "C:\"(string close), which is invalid
 
-        , # -reuse has benifits of reusing the previous instance 
+        # -reuse has benifits of reusing the previous instance 
 
-        , # -run will run preconfigured env, I've chosen {cmd::Cmder}
+        # -run will run preconfigured env, I've chosen {cmd::Cmder}
         $Command = "/x `"-Dir \`"%V% \`" -reuse -run {cmd::Cmder}`""
 
-        , # Defaults to the icons folder in the cmder package.
+        # Defaults to the icons folder in the cmder package.
         $icon = (Split-Path $PathToExe | Join-Path -ChildPath 'icons/cmder.ico')
     )
     Begin

--- a/scripts/utils.ps1
+++ b/scripts/utils.ps1
@@ -172,7 +172,7 @@ function Register-Cmder() {
         # Text for the context menu item.
         $MenuText = "Cmder Here"
 
-        # Defaults to the current cmder directory when run from cmder.
+        , # Defaults to the current cmder directory when run from cmder.
         $PathToExe = (Join-Path $env:CMDER_ROOT "cmder.exe")
 
         # Commands the context menu will execute
@@ -190,10 +190,10 @@ function Register-Cmder() {
 
         # -reuse has benifits of reusing the previous instance 
 
-        # -run will run preconfigured env, I've chosen {cmd::Cmder}
+        , # -run will run preconfigured env, I've chosen {cmd::Cmder}
         $Command = "/x `"-Dir \`"%V% \`" -reuse -run {cmd::Cmder}`""
 
-        # Defaults to the icons folder in the cmder package.
+        , # Defaults to the icons folder in the cmder package.
         $icon = (Split-Path $PathToExe | Join-Path -ChildPath 'icons/cmder.ico')
     )
     Begin

--- a/scripts/utils.ps1
+++ b/scripts/utils.ps1
@@ -175,8 +175,23 @@ function Register-Cmder() {
         , # Defaults to the current cmder directory when run from cmder.
         $PathToExe = (Join-Path $env:CMDER_ROOT "cmder.exe")
 
-        , # Commands the context menu will execute.
-        $Command = "%V"
+        , # Commands the context menu will execute
+
+        , # /x for ConEmu Extra Argument. Adds lots of possibilitites
+
+        , # `"-Dir \`"%V% \`" is that passed argument where directory is properly escaped
+        , # NOTE:
+        , # Needs an additional space after %V% due to how windows handles files in
+        , # context menu. If the current dir is `C:\` and someone opens cmder from
+        , # there by shift + right click, the command becomes: `..."... \"C:\ \" ..."`
+        , # Interprets to "C:\ ", which is valid
+        , # otherwise, the command becomes `..."... \"C:\\" ..."`
+        , # Interprets to "C:\"(string close), which is invalid
+
+        , # -reuse has benifits of reusing the previous instance 
+
+        , # -run will run preconfigured env, I've chosen {cmd::Cmder}
+        $Command = "/x `"-Dir \`"%V% \`" -reuse -run {cmd::Cmder}`""
 
         , # Defaults to the icons folder in the cmder package.
         $icon = (Split-Path $PathToExe | Join-Path -ChildPath 'icons/cmder.ico')
@@ -190,12 +205,14 @@ function Register-Cmder() {
         New-Item         -Path "HKCR:\Directory\Shell\Cmder" -Force -Value $MenuText
         New-ItemProperty -Path "HKCR:\Directory\Shell\Cmder" -Force -Name "Icon" -Value `"$icon`"
         New-ItemProperty -Path "HKCR:\Directory\Shell\Cmder" -Force -Name "NoWorkingDirectory"
-        New-Item         -Path "HKCR:\Directory\Shell\Cmder\Command" -Force -Value "`"$PathToExe`" `"$Command`" "
+        # Already Escaped Command. No need to escape again
+        New-Item         -Path "HKCR:\Directory\Shell\Cmder\Command" -Force -Value "`"$PathToExe`" $Command "
 
         New-Item         -Path "HKCR:\Directory\Background\Shell\Cmder" -Force -Value $MenuText
         New-ItemProperty -Path "HKCR:\Directory\Background\Shell\Cmder" -Force -Name "Icon" -Value `"$icon`"
         New-ItemProperty -Path "HKCR:\Directory\Background\Shell\Cmder" -Force -Name "NoWorkingDirectory"
-        New-Item         -Path "HKCR:\Directory\Background\Shell\Cmder\Command" -Force -Value "`"$PathToExe`" `"$Command`" "
+        # Already Escaped Command. No need to escape again
+        New-Item         -Path "HKCR:\Directory\Background\Shell\Cmder\Command" -Force -Value "`"$PathToExe`" $Command "
     }
     End
     {


### PR DESCRIPTION
I have added support for custom Context Menu, where predefined Task can be started on clicking "Terminal Here".
Also, it adds support for passing params to ConEmu, which can be utilized to use the whole ConEmu ecosystem