### PR TITLE
Cmder for Windows  - Add `Bash`, `Powershell`, `mintty` and run as Admin.

### DIFF
--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -516,8 +516,8 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 		else
 		{
 			PathCombine(terminalPath, winDir, L"system32\\cmd.exe");
-	    }
-    }
+		}
+	}
 
 	if (!streqi(cmderStart.c_str(), L""))
 	{

--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -135,6 +135,7 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 	wchar_t initCmd[MAX_PATH] = { 0 };
 	wchar_t initPowerShell[MAX_PATH] = { 0 };
 	wchar_t initBash[MAX_PATH] = { 0 };
+	wchar_t initMintty[MAX_PATH] = { 0 };
 	wchar_t vendoredGit[MAX_PATH] = { 0 };
 	wchar_t amdx64Git[MAX_PATH] = { 0 };
 	wchar_t x86Git[MAX_PATH] = { 0 };
@@ -528,6 +529,7 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 		{
 			PathCombine(terminalPath, winDir, L"System32\\WindowsPowerShell\\v1.0\\powershell.exe");
 		}
+		/*
 		else if (streqi(cmderTask.c_str(), L"mintty"))
 		{
 			if (PathFileExists(vendoredGit))
@@ -543,6 +545,7 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 				PathCombine(terminalPath, x86Git, L"git-bash.exe");
 			}
 		}
+		*/
 	}
 
 	if (!streqi(cmderStart.c_str(), L""))
@@ -581,6 +584,7 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 	PathCombine(initCmd, vendorDir, L"init.bat");
 	PathCombine(initPowerShell, vendorDir, L"profile.ps1");
 	PathCombine(initBash, vendorDir, L"start_git_bash.cmd");
+	PathCombine(initMintty, vendorDir, L"start_git_mintty.cmd");
 
 	if (!streqi(cmderTask.c_str(), L""))
 	{
@@ -600,6 +604,10 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 			else if (streqi(cmderTask.c_str(), L"bash"))
 			{
 				swprintf_s(args, L"%s /c \"%s\"", args, initBash);
+			}
+			else if (streqi(cmderTask.c_str(), L"mintty"))
+			{
+				swprintf_s(args, L"%s /c \"%s\"", args, initMintty);
 			}
 			else if (streqi(cmderTask.c_str(), L"cmder"))
 			{

--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -131,8 +131,10 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 	wchar_t windowsTerminalDir[MAX_PATH] = { 0 };
 	wchar_t conEmuDir[MAX_PATH] = { 0 };
 	wchar_t winDir[MAX_PATH] = { 0 };
-	wchar_t emulatorPath[MAX_PATH] = { 0 };
-
+	wchar_t vendorDir[MAX_PATH] = { 0 };
+	wchar_t initCmd[MAX_PATH] = { 0 };
+	wchar_t initPowerShell[MAX_PATH] = { 0 };
+	wchar_t initBash[MAX_PATH] = { 0 };
 
 	std::wstring cmderStart = path;
 	std::wstring cmderTask = taskName;
@@ -255,8 +257,9 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 		}
 	}
 
-	PathCombine(windowsTerminalDir, exeDir, L"vendor\\windows-terminal");
-	PathCombine(conEmuDir, exeDir, L"vendor\\conemu-maximus5");
+	PathCombine(vendorDir, exeDir, L"vendor");
+	PathCombine(windowsTerminalDir, vendorDir, L"windows-terminal");
+	PathCombine(conEmuDir, vendorDir, L"conemu-maximus5");
 	GetEnvironmentVariable(L"WINDIR", winDir, MAX_PATH);
 
 	if (PathFileExists(windowsTerminalDir))
@@ -317,7 +320,8 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 		{
 			if (!CopyFile(cpuCfgPath, cfgPath, FALSE))
 			{
-				if (PathFileExists(windowsTerminalDir)) {
+				if (PathFileExists(windowsTerminalDir))
+				{
 					MessageBox(NULL,
 						(GetLastError() == ERROR_ACCESS_DENIED)
 						? L"Failed to copy config/windows_terminal_%COMPUTERNAME%_settings.json file to vendor/windows-terminal/settings/settings.json! Access Denied."
@@ -343,7 +347,8 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 			{
 				if (!CopyFile(cfgPath, userCfgPath, FALSE))
 				{
-					if (PathFileExists(windowsTerminalDir)) {
+					if (PathFileExists(windowsTerminalDir))
+					{
 						MessageBox(NULL,
 							(GetLastError() == ERROR_ACCESS_DENIED)
 							? L"Failed to copy vendor/windows-terminal/settings/settings.json file to config/windows_terminal_settings.json! Access Denied."
@@ -364,7 +369,8 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 			{
 				if (!CopyFile(userCfgPath, cfgPath, FALSE))
 				{
-					if (PathFileExists(windowsTerminalDir)) {
+					if (PathFileExists(windowsTerminalDir))
+					{
 						MessageBox(NULL,
 							(GetLastError() == ERROR_ACCESS_DENIED)
 							? L"Failed to copy config/user_windows_terminal_settings.json file to vendor/windows-terminal/settings/settings.json! Access Denied."
@@ -392,7 +398,8 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 		{
 			if (!CopyFile(cfgPath, userCfgPath, FALSE))
 			{
-				if (PathFileExists(windowsTerminalDir)) {
+				if (PathFileExists(windowsTerminalDir))
+				{
 					MessageBox(NULL,
 						(GetLastError() == ERROR_ACCESS_DENIED)
 						? L"Failed to copy vendor/windows-terminal/settings/settings.json file to config/user_windows_terminal_settings.json! Access Denied."
@@ -412,7 +419,8 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 			{
 				if (!CopyFile(defaultCfgPath, cfgPath, FALSE))
 				{
-					if (PathFileExists(windowsTerminalDir)) {
+					if (PathFileExists(windowsTerminalDir))
+					{
 						MessageBox(NULL,
 							(GetLastError() == ERROR_ACCESS_DENIED)
 							? L"Failed to copy vendor/windows-terminal_default_settings_settings.json file to vendor/windows-terminal/settings/settings.json! Access Denied."
@@ -428,7 +436,7 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 						exit(1);
 					}
 				}
-			}
+				}
 		}
 		else if (!CopyFile(defaultCfgPath, cfgPath, FALSE) && PathFileExists(conEmuDir))
 		{
@@ -436,14 +444,15 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 				(GetLastError() == ERROR_ACCESS_DENIED)
 				? L"Failed to copy vendor/ConEmu.xml.default file to vendor/conemu-maximus5/ConEmu.xml! Access Denied."
 				: L"Failed to copy vendor/ConEmu.xml.default file to vendor/conemu-maximus5/ConEmu.xml!", MB_TITLE, MB_ICONSTOP);
-				exit(1);
+			exit(1);
 		}
 	}
 	else if (wcscmp(cfgPath, L"") == 0 && PathFileExists(cfgPath)) // vendor/conemu-maximus5/ConEmu.xml exists, copy vendor/conemu-maximus5/ConEmu.xml to config/user_conemu.xml
 	{
 		if (!CopyFile(cfgPath, userCfgPath, FALSE))
 		{
-			if (PathFileExists(windowsTerminalDir)) {
+			if (PathFileExists(windowsTerminalDir))
+			{
 				MessageBox(NULL,
 					(GetLastError() == ERROR_ACCESS_DENIED)
 					? L"Failed to copy vendor/windows-terminal/settings/settings.json file to config/user_windows_terminal_settings_settings.json! Access Denied."
@@ -464,9 +473,10 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 	}
 	else if (wcscmp(defaultCfgPath, L"") == 0) // '/c [path]' was specified and 'vendor/ConEmu.xml.default' config exists, copy Cmder 'vendor/ConEmu.xml.default' file to '[user specified path]/config/user_ConEmu.xml'.
 	{
-		if ( ! CopyFile(defaultCfgPath, userCfgPath, FALSE))
+		if (!CopyFile(defaultCfgPath, userCfgPath, FALSE))
 		{
-			if (PathFileExists(windowsTerminalDir)) {
+			if (PathFileExists(windowsTerminalDir))
+			{
 				MessageBox(NULL,
 					(GetLastError() == ERROR_ACCESS_DENIED)
 					? L"Failed to copy vendor/windows-terminal_default_settings_settings.json file to [user specified path]/config/user_windows_terminal_settings.json! Access Denied."
@@ -487,21 +497,27 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 
 	SYSTEM_INFO sysInfo;
 	GetNativeSystemInfo(&sysInfo);
-	if (PathFileExists(windowsTerminalDir)) {
+	if (PathFileExists(windowsTerminalDir))
+	{
 		PathCombine(terminalPath, exeDir, L"vendor\\windows-terminal\\WindowsTerminal.exe");
 	}
 	else if (PathFileExists(conEmuDir))
 	{
+		swprintf_s(args, L"%s /Icon \"%s\"", args, icoPath);
+		swprintf_s(args, L"%s /title \"%s\"", args, cmderTitle.c_str());
 		PathCombine(terminalPath, exeDir, L"vendor\\conemu-maximus5\\ConEmu64.exe");
 	}
 	else
 	{
-		PathCombine(terminalPath, winDir, L"system32\\cmd.exe");
-	}
-
-	if (!PathFileExists(windowsTerminalDir)) {
-		swprintf_s(args, L"%s /Icon \"%s\"", args, icoPath);
-	}
+		if (streqi(cmderTask.c_str(), L"powershell"))
+		{
+			PathCombine(terminalPath, winDir, L"System32\\WindowsPowerShell\\v1.0\\powershell.exe");
+		}
+		else
+		{
+			PathCombine(terminalPath, winDir, L"system32\\cmd.exe");
+	    }
+    }
 
 	if (!streqi(cmderStart.c_str(), L""))
 	{
@@ -521,13 +537,6 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 		}
 	}
 
-	if (!streqi(cmderTitle.c_str(), L""))
-	{
-		if (!PathFileExists(windowsTerminalDir)) {
-			swprintf_s(args, L"%s /title \"%s\"", args, cmderTitle.c_str());
-		}
-	}
-
 	if (cfgRoot.length() != 0)
 	{
 		if (!PathFileExists(windowsTerminalDir)) {
@@ -543,6 +552,10 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 	// The `/run` arg and its value MUST be the last arg of ConEmu
 	// see : https://conemu.github.io/en/ConEmuArgs.html
 	// > This must be the last used switch (excepting -new_console and -cur_console)
+	PathCombine(initCmd, vendorDir, L"init.bat");
+	PathCombine(initPowerShell, vendorDir, L"profile.ps1");
+	PathCombine(initBash, vendorDir, L"start_git_bash.cmd");
+
 	if (!streqi(cmderTask.c_str(), L""))
 	{
 		if (PathFileExists(windowsTerminalDir)) {
@@ -554,7 +567,18 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 		}
 		else
 		{
-			swprintf_s(args, L"%s %s", args, cmderTask.c_str());
+			if (streqi(cmderTask.c_str(), L"powershell"))
+			{
+				swprintf_s(args, L"%s -ExecutionPolicy Bypass -NoLogo -NoProfile -NoExit -Command \"Invoke-Expression 'Import-Module ''%s'''\"", args, initPowerShell);
+			}
+			else if (streqi(cmderTask.c_str(), L"bash"))
+			{
+				swprintf_s(args, L"%s /k \"%s\"", args, initBash);
+			}
+			else
+			{
+				swprintf_s(args, L"%s /k \"%s\"", args, initCmd);
+			}
 		}
 	}
 
@@ -581,7 +605,8 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 
 	if (!CreateProcess(terminalPath, args, NULL, NULL, false, 0, NULL, NULL, &si, &pi))
 	{
-		if (PathFileExists(windowsTerminalDir)) {
+		if (PathFileExists(windowsTerminalDir))
+		{
 			MessageBox(NULL, _T("Unable to create the Windows Terminal process!"), _T("Error"), MB_OK);
 		}
 		else if (PathFileExists(conEmuDir))
@@ -726,7 +751,6 @@ cmderOptions GetOption()
 	wchar_t conEmuDir[MAX_PATH] = { 0 };
 	wchar_t vendorDir[MAX_PATH] = { 0 };
 	wchar_t exeDir[MAX_PATH] = { 0 };
-	wchar_t cmdInit[MAX_PATH] = { 0 };
 
 	GetModuleFileName(NULL, exeDir, sizeof(exeDir));
 	PathRemoveFileSpec(exeDir);
@@ -734,7 +758,6 @@ cmderOptions GetOption()
 	PathCombine(vendorDir, exeDir, L"vendor");
 	PathCombine(windowsTerminalDir, vendorDir, L"windows-terminal");
 	PathCombine(conEmuDir, vendorDir, L"ConEmu-Maximus5");
-	PathCombine(cmdInit, vendorDir, L"init.bat");
 
 	szArgList = CommandLineToArgvW(GetCommandLine(), &argCount);
 
@@ -849,7 +872,7 @@ cmderOptions GetOption()
 				{
 					szArgList[i][len - 1] = '\0';
 				}
-
+		
 				if (PathFileExists(szArgList[i]))
 				{
 					cmderOptions.cmderStart = szArgList[i];
@@ -865,14 +888,11 @@ cmderOptions GetOption()
 				cmderOptions.error = true;
 			}
 		}
-
 	}
 
-	if (!PathFileExists(windowsTerminalDir) && !PathFileExists(conEmuDir))
+	if (!PathFileExists(windowsTerminalDir) && !PathFileExists(conEmuDir) && streqi(cmderOptions.cmderTask.c_str(), L""))
 	{
-		cmderOptions.cmderTask = L"/k \"";
-		cmderOptions.cmderTask += cmdInit;
-		cmderOptions.cmderTask += L"\"";
+		cmderOptions.cmderTask = L"cmder";
 	}
 
 	if (cmderOptions.error == true)
@@ -906,17 +926,16 @@ int APIENTRY _tWinMain(_In_ HINSTANCE hInstance,
 
 	GetModuleFileName(NULL, exeDir, sizeof(exeDir));
 	PathRemoveFileSpec(exeDir);
-
-  PathCombine(windowsTerminalDir, exeDir, L"vendor\\windows-terminal");
+	PathCombine(windowsTerminalDir, exeDir, L"vendor\\windows-terminal");
 
 	if (cmderOptions.registerApp == true)
 	{
-    if (PathFileExists(windowsTerminalDir))
-    {
-			RegisterShellMenu(cmderOptions.cmderRegScope, SHELL_MENU_REGISTRY_PATH_BACKGROUND, cmderOptions.cmderCfgRoot, cmderOptions.cmderSingle);
-			RegisterShellMenu(cmderOptions.cmderRegScope, SHELL_MENU_REGISTRY_PATH_LISTITEM, cmderOptions.cmderCfgRoot, cmderOptions.cmderSingle);
-			RegisterShellMenu(cmderOptions.cmderRegScope, SHELL_MENU_REGISTRY_DRIVE_PATH_BACKGROUND, cmderOptions.cmderCfgRoot, cmderOptions.cmderSingle);
-			RegisterShellMenu(cmderOptions.cmderRegScope, SHELL_MENU_REGISTRY_DRIVE_PATH_LISTITEM, cmderOptions.cmderCfgRoot, cmderOptions.cmderSingle);
+		if (PathFileExists(windowsTerminalDir))
+		{
+				RegisterShellMenu(cmderOptions.cmderRegScope, SHELL_MENU_REGISTRY_PATH_BACKGROUND, cmderOptions.cmderCfgRoot, cmderOptions.cmderSingle);
+				RegisterShellMenu(cmderOptions.cmderRegScope, SHELL_MENU_REGISTRY_PATH_LISTITEM, cmderOptions.cmderCfgRoot, cmderOptions.cmderSingle);
+				RegisterShellMenu(cmderOptions.cmderRegScope, SHELL_MENU_REGISTRY_DRIVE_PATH_BACKGROUND, cmderOptions.cmderCfgRoot, cmderOptions.cmderSingle);
+				RegisterShellMenu(cmderOptions.cmderRegScope, SHELL_MENU_REGISTRY_DRIVE_PATH_LISTITEM, cmderOptions.cmderCfgRoot, cmderOptions.cmderSingle);
 		}
 		else
 		{

--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -932,10 +932,10 @@ int APIENTRY _tWinMain(_In_ HINSTANCE hInstance,
 	{
 		if (PathFileExists(windowsTerminalDir))
 		{
-				RegisterShellMenu(cmderOptions.cmderRegScope, SHELL_MENU_REGISTRY_PATH_BACKGROUND, cmderOptions.cmderCfgRoot, cmderOptions.cmderSingle);
-				RegisterShellMenu(cmderOptions.cmderRegScope, SHELL_MENU_REGISTRY_PATH_LISTITEM, cmderOptions.cmderCfgRoot, cmderOptions.cmderSingle);
-				RegisterShellMenu(cmderOptions.cmderRegScope, SHELL_MENU_REGISTRY_DRIVE_PATH_BACKGROUND, cmderOptions.cmderCfgRoot, cmderOptions.cmderSingle);
-				RegisterShellMenu(cmderOptions.cmderRegScope, SHELL_MENU_REGISTRY_DRIVE_PATH_LISTITEM, cmderOptions.cmderCfgRoot, cmderOptions.cmderSingle);
+			RegisterShellMenu(cmderOptions.cmderRegScope, SHELL_MENU_REGISTRY_PATH_BACKGROUND, cmderOptions.cmderCfgRoot, cmderOptions.cmderSingle);
+			RegisterShellMenu(cmderOptions.cmderRegScope, SHELL_MENU_REGISTRY_PATH_LISTITEM, cmderOptions.cmderCfgRoot, cmderOptions.cmderSingle);
+			RegisterShellMenu(cmderOptions.cmderRegScope, SHELL_MENU_REGISTRY_DRIVE_PATH_BACKGROUND, cmderOptions.cmderCfgRoot, cmderOptions.cmderSingle);
+			RegisterShellMenu(cmderOptions.cmderRegScope, SHELL_MENU_REGISTRY_DRIVE_PATH_LISTITEM, cmderOptions.cmderCfgRoot, cmderOptions.cmderSingle);
 		}
 		else
 		{

--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -599,7 +599,7 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 	si.dwFlags = STARTF_TITLEISAPPID;
 #endif
 	PROCESS_INFORMATION pi;
-	
+
 	// MessageBox(NULL, terminalPath, _T("Error"), MB_OK);
 	// MessageBox(NULL, args, _T("Error"), MB_OK);
 
@@ -872,7 +872,7 @@ cmderOptions GetOption()
 				{
 					szArgList[i][len - 1] = '\0';
 				}
-		
+
 				if (PathFileExists(szArgList[i]))
 				{
 					cmderOptions.cmderStart = szArgList[i];

--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -105,7 +105,7 @@ bool FileExists(const wchar_t * filePath)
 	return false;
 }
 
-void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstring taskName = L"", std::wstring title = L"", std::wstring iconPath = L"", std::wstring cfgRoot = L"", bool use_user_cfg = true, std::wstring conemu_args = L"")
+void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstring taskName = L"", std::wstring title = L"", std::wstring iconPath = L"", std::wstring cfgRoot = L"", bool use_user_cfg = true, std::wstring conemu_args = L"", bool admin = false)
 {
 #if USE_TASKBAR_API
 	wchar_t appId[MAX_PATH] = { 0 };
@@ -602,8 +602,36 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 
 	// MessageBox(NULL, terminalPath, _T("Error"), MB_OK);
 	// MessageBox(NULL, args, _T("Error"), MB_OK);
+	// Let's try to rerun as Administrator
+	SHELLEXECUTEINFO sei = { sizeof(sei) };
+	sei.fMask = SEE_MASK_NOASYNC | SEE_MASK_NOCLOSEPROCESS;
+	sei.lpVerb = L"runas";
+	sei.lpFile = terminalPath;
+	sei.lpParameters = args;
+	sei.nShow = SW_SHOWNORMAL;
+	
+	if (admin && ShellExecuteEx(&sei))
+	{
+		if (!sei.hProcess)
+		{
+			Sleep(500);
+			_ASSERTE(sei.hProcess != nullptr);
+		}
 
-	if (!CreateProcess(terminalPath, args, NULL, NULL, false, 0, NULL, NULL, &si, &pi))
+		if (sei.hProcess)
+		{
+			WaitForSingleObject(sei.hProcess, INFINITE);
+		}
+
+		// int nZone = 0;
+		// if (!HasZoneIdentifier(lsFile, nZone)
+		// 	|| (nZone != 0 /*LocalComputer*/))
+		// {
+		// 	// Assuming that elevated copy has fixed all zone problems
+		// 	break;
+		// }
+	}
+	else if (!CreateProcess(terminalPath, args, NULL, NULL, false, 0, NULL, NULL, &si, &pi))
 	{
 		if (PathFileExists(windowsTerminalDir))
 		{
@@ -734,6 +762,7 @@ struct cmderOptions
 	std::wstring cmderIcon = L"";
 	std::wstring cmderRegScope = L"USER";
 	std::wstring cmderTerminalArgs = L"";
+	bool cmderAdmin = false;
 	bool cmderSingle = false;
 	bool cmderUserCfg = true;
 	bool registerApp = false;
@@ -821,6 +850,10 @@ cmderOptions GetOption()
 			else if (_wcsicmp(L"/m", szArgList[i]) == 0 && !PathFileExists(windowsTerminalDir) && PathFileExists(conEmuDir))
 			{
 				cmderOptions.cmderUserCfg = false;
+			}
+			else if (_wcsicmp(L"/a", szArgList[i]) == 0 && !PathFileExists(windowsTerminalDir) && !PathFileExists(conEmuDir))
+			{
+				cmderOptions.cmderAdmin = true;
 			}
 			else if (_wcsicmp(L"/register", szArgList[i]) == 0)
 			{
@@ -958,8 +991,7 @@ int APIENTRY _tWinMain(_In_ HINSTANCE hInstance,
 	}
 	else
 	{
-		StartCmder(cmderOptions.cmderStart, cmderOptions.cmderSingle, cmderOptions.cmderTask, cmderOptions.cmderTitle, cmderOptions.cmderIcon, cmderOptions.cmderCfgRoot, cmderOptions.cmderUserCfg, cmderOptions.cmderTerminalArgs);
-	}
+		StartCmder(cmderOptions.cmderStart, cmderOptions.cmderSingle, cmderOptions.cmderTask, cmderOptions.cmderTitle, cmderOptions.cmderIcon, cmderOptions.cmderCfgRoot, cmderOptions.cmderUserCfg, cmderOptions.cmderTerminalArgs, cmderOptions.cmderAdmin);	}
 
 	return 0;
 }

--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -1,4 +1,4 @@
-#include <windows.h>
+#include <windows.h>/
 #include <tchar.h>
 #include <Shlwapi.h>
 #include "resource.h"
@@ -130,6 +130,7 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 	wchar_t userConEmuCfgPath[MAX_PATH] = { 0 };
 	wchar_t windowsTerminalDir[MAX_PATH] = { 0 };
 	wchar_t conEmuDir[MAX_PATH] = { 0 };
+	wchar_t winDir[MAX_PATH] = { 0 };
 	wchar_t emulatorPath[MAX_PATH] = { 0 };
 
 
@@ -256,6 +257,7 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 
 	PathCombine(windowsTerminalDir, exeDir, L"vendor\\windows-terminal");
 	PathCombine(conEmuDir, exeDir, L"vendor\\conemu-maximus5");
+	GetEnvironmentVariable(L"WINDIR", winDir, MAX_PATH);
 
 	if (PathFileExists(windowsTerminalDir))
 	{
@@ -272,7 +274,7 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 		// Set path to Cmder user ConEmu config file
 		PathCombine(userCfgPath, userConfigDirPath, L"user_windows_terminal_settings.json");
 	}
-	else
+	else if (PathFileExists(conEmuDir))
 	{
 		// Set path to vendored ConEmu config file
 		PathCombine(cfgPath, conEmuDir, L"ConEmu.xml");
@@ -288,7 +290,7 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 		PathCombine(userCfgPath, userConfigDirPath, L"user-ConEmu.xml");
 	}
 
-	if (PathFileExists(cpuCfgPath) || use_user_cfg == false) // config/ConEmu-%COMPUTERNAME%.xml file exists or /m was specified on command line, use machine specific config.
+	if (wcscmp(cpuCfgPath, L"") == 0 && (PathFileExists(cpuCfgPath) || use_user_cfg == false)) // config/ConEmu-%COMPUTERNAME%.xml file exists or /m was specified on command line, use machine specific config.
 	{
 		if (cfgRoot.length() == 0) // '/c [path]' was NOT specified
 		{
@@ -301,7 +303,8 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 						: L"Failed to copy vendor/windows-terminal/settings/settings.json file to config/windows_teerminal_%COMPUTERNAME%_settigns.json!", MB_TITLE, MB_ICONSTOP);
 					exit(1);
 				}
-				else {
+				else if (PathFileExists(conEmuDir))
+				{
 					MessageBox(NULL,
 						(GetLastError() == ERROR_ACCESS_DENIED)
 						? L"Failed to copy vendor/conemu-maximus5/ConEmu.xml file to config/ConEmu-%COMPUTERNAME%.xml! Access Denied."
@@ -321,7 +324,8 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 						: L"Failed to copy config/windows_terminal_%COMPUTERNAME%_settings.json file to vendor/windows-terminal/settings/settings.json!", MB_TITLE, MB_ICONSTOP);
 					exit(1);
 				}
-				else {
+				else if (PathFileExists(conEmuDir))
+				{
 					MessageBox(NULL,
 						(GetLastError() == ERROR_ACCESS_DENIED)
 						? L"Failed to copy config/ConEmu-%COMPUTERNAME%.xml file to vendor/conemu-maximus5/ConEmu.xml! Access Denied."
@@ -331,7 +335,7 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 			}
 		}
 	}
-	else if (PathFileExists(userCfgPath)) // config/user_conemu.xml exists, use it.
+	else if (wcscmp(userCfgPath, L"") == 0 && PathFileExists(userCfgPath)) // config/user_conemu.xml exists, use it.
 	{
 		if (cfgRoot.length() == 0) // '/c [path]' was NOT specified
 		{
@@ -346,7 +350,7 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 							: L"Failed to copy vendor/windows-terminal/settings/settings.json file to config/windows_teerminal_settigns.json!", MB_TITLE, MB_ICONSTOP);
 						exit(1);
 					}
-					else
+					else if (PathFileExists(conEmuDir))
 					{
 						MessageBox(NULL,
 							(GetLastError() == ERROR_ACCESS_DENIED)
@@ -367,7 +371,7 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 							: L"Failed to copy config/user_windows_terminal_settings.json file to vendor/windows-terminal/settings/settings.json!", MB_TITLE, MB_ICONSTOP);
 						exit(1);
 					}
-					else
+					else if (PathFileExists(conEmuDir))
 					{
 						MessageBox(NULL,
 							(GetLastError() == ERROR_ACCESS_DENIED)
@@ -395,14 +399,14 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 						: L"Failed to copy vendor/windows-terminal/settings/settings.json file to config/user_windows_terminal_settigns.json!", MB_TITLE, MB_ICONSTOP);
 					exit(1);
 				}
-				else
+				else if (PathFileExists(conEmuDir))
 				{
 					MessageBox(NULL,
 						(GetLastError() == ERROR_ACCESS_DENIED)
 						? L"Failed to copy vendor/conemu-maximus5/ConEmu.xml file to config/user-conemu.xml! Access Denied."
 						: L"Failed to copy vendor/conemu-maximus5/ConEmu.xml file to config/user-conemu.xml!", MB_TITLE, MB_ICONSTOP);
 					exit(1);
-				}		
+				}
 			}
 			else // vendor/ConEmu.xml.default config exists, copy Cmder vendor/ConEmu.xml.default file to vendor/conemu-maximus5/ConEmu.xml.
 			{
@@ -415,7 +419,7 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 							: L"Failed to copy vendor/windows-terminal_default_settings_settings.json file to vendor/windows-terminal/settings/settigns.json!", MB_TITLE, MB_ICONSTOP);
 						exit(1);
 					}
-					else
+					else if (PathFileExists(conEmuDir))
 					{
 						MessageBox(NULL,
 							(GetLastError() == ERROR_ACCESS_DENIED)
@@ -426,18 +430,16 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 				}
 			}
 		}
-		else {
-			if (!CopyFile(defaultCfgPath, cfgPath, FALSE))
-			{
-				MessageBox(NULL,
-					(GetLastError() == ERROR_ACCESS_DENIED)
-					? L"Failed to copy vendor/ConEmu.xml.default file to vendor/conemu-maximus5/ConEmu.xml! Access Denied."
-					: L"Failed to copy vendor/ConEmu.xml.default file to vendor/conemu-maximus5/ConEmu.xml!", MB_TITLE, MB_ICONSTOP);
+		else if (!CopyFile(defaultCfgPath, cfgPath, FALSE) && PathFileExists(conEmuDir))
+		{
+			MessageBox(NULL,
+				(GetLastError() == ERROR_ACCESS_DENIED)
+				? L"Failed to copy vendor/ConEmu.xml.default file to vendor/conemu-maximus5/ConEmu.xml! Access Denied."
+				: L"Failed to copy vendor/ConEmu.xml.default file to vendor/conemu-maximus5/ConEmu.xml!", MB_TITLE, MB_ICONSTOP);
 				exit(1);
-			}
 		}
 	}
-	else if (PathFileExists(cfgPath)) // vendor/conemu-maximus5/ConEmu.xml exists, copy vendor/conemu-maximus5/ConEmu.xml to config/user_conemu.xml
+	else if (wcscmp(cfgPath, L"") == 0 && PathFileExists(cfgPath)) // vendor/conemu-maximus5/ConEmu.xml exists, copy vendor/conemu-maximus5/ConEmu.xml to config/user_conemu.xml
 	{
 		if (!CopyFile(cfgPath, userCfgPath, FALSE))
 		{
@@ -460,7 +462,7 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 
 		PathCombine(userConEmuCfgPath, userConfigDirPath, L"user-ConEmu.xml");
 	}
-	else // '/c [path]' was specified and 'vendor/ConEmu.xml.default' config exists, copy Cmder 'vendor/ConEmu.xml.default' file to '[user specified path]/config/user_ConEmu.xml'.
+	else if (wcscmp(defaultCfgPath, L"") == 0) // '/c [path]' was specified and 'vendor/ConEmu.xml.default' config exists, copy Cmder 'vendor/ConEmu.xml.default' file to '[user specified path]/config/user_ConEmu.xml'.
 	{
 		if ( ! CopyFile(defaultCfgPath, userCfgPath, FALSE))
 		{
@@ -488,9 +490,13 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 	if (PathFileExists(windowsTerminalDir)) {
 		PathCombine(terminalPath, exeDir, L"vendor\\windows-terminal\\WindowsTerminal.exe");
 	}
-	else
+	else if (PathFileExists(conEmuDir))
 	{
 		PathCombine(terminalPath, exeDir, L"vendor\\conemu-maximus5\\ConEmu64.exe");
+	}
+	else
+	{
+		PathCombine(terminalPath, winDir, L"system32\\cmd.exe");
 	}
 
 	if (!PathFileExists(windowsTerminalDir)) {
@@ -542,9 +548,13 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 		if (PathFileExists(windowsTerminalDir)) {
 			swprintf_s(args, L"%s -p \"%s\"", args, cmderTask.c_str());
 		}
-		else
+		else if (PathFileExists(conEmuDir))
 		{
 			swprintf_s(args, L"%s /run {%s}", args, cmderTask.c_str());
+		}
+		else
+		{
+			swprintf_s(args, L"%s %s", args, cmderTask.c_str());
 		}
 	}
 
@@ -565,13 +575,22 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 	si.dwFlags = STARTF_TITLEISAPPID;
 #endif
 	PROCESS_INFORMATION pi;
-	if (!CreateProcess(terminalPath, args, NULL, NULL, false, 0, NULL, NULL, &si, &pi)) {
+	
+	// MessageBox(NULL, terminalPath, _T("Error"), MB_OK);
+	// MessageBox(NULL, args, _T("Error"), MB_OK);
+
+	if (!CreateProcess(terminalPath, args, NULL, NULL, false, 0, NULL, NULL, &si, &pi))
+	{
 		if (PathFileExists(windowsTerminalDir)) {
 			MessageBox(NULL, _T("Unable to create the Windows Terminal process!"), _T("Error"), MB_OK);
 		}
-		else
+		else if (PathFileExists(conEmuDir))
 		{
 			MessageBox(NULL, _T("Unable to create the ConEmu process!"), _T("Error"), MB_OK);
+		}
+		else
+		{
+			MessageBox(NULL, _T("Unable to create the Cmd process!"), _T("Error"), MB_OK);
 		}
 		return;
 	}
@@ -704,18 +723,23 @@ cmderOptions GetOption()
 	int argCount;
 
 	wchar_t windowsTerminalDir[MAX_PATH] = { 0 };
+	wchar_t conEmuDir[MAX_PATH] = { 0 };
+	wchar_t vendorDir[MAX_PATH] = { 0 };
 	wchar_t exeDir[MAX_PATH] = { 0 };
+	wchar_t cmdInit[MAX_PATH] = { 0 };
 
 	GetModuleFileName(NULL, exeDir, sizeof(exeDir));
 	PathRemoveFileSpec(exeDir);
 
-	PathCombine(windowsTerminalDir, exeDir, L"vendor\\windows-terminal");
+	PathCombine(vendorDir, exeDir, L"vendor");
+	PathCombine(windowsTerminalDir, vendorDir, L"windows-terminal");
+	PathCombine(conEmuDir, vendorDir, L"ConEmu-Maximus5");
+	PathCombine(cmdInit, vendorDir, L"init.bat");
 
 	szArgList = CommandLineToArgvW(GetCommandLine(), &argCount);
 
 	for (int i = 1; i < argCount; i++)
 	{
-
 		// MessageBox(NULL, szArgList[i], L"Arglist contents", MB_OK);
 		if (cmderOptions.error == false) {
 			if (_wcsicmp(L"/c", szArgList[i]) == 0)
@@ -752,26 +776,26 @@ cmderOptions GetOption()
 					MessageBox(NULL, szArgList[i + 1], L"/START - Folder does not exist!", MB_OK);
 				}
 			}
-			else if (_wcsicmp(L"/task", szArgList[i]) == 0)
+			else if (_wcsicmp(L"/task", szArgList[i]) == 0 || PathFileExists(windowsTerminalDir) || PathFileExists(conEmuDir))
 			{
 				cmderOptions.cmderTask = szArgList[i + 1];
 				i++;
 			}
-			else if (_wcsicmp(L"/title", szArgList[i]) == 0 && !PathFileExists(windowsTerminalDir))
+			else if (_wcsicmp(L"/title", szArgList[i]) == 0 && !PathFileExists(windowsTerminalDir) && PathFileExists(conEmuDir))
 			{
 				cmderOptions.cmderTitle = szArgList[i + 1];
 				i++;
 			}
-			else if (_wcsicmp(L"/icon", szArgList[i]) == 0 && !PathFileExists(windowsTerminalDir))
+			else if (_wcsicmp(L"/icon", szArgList[i]) == 0 && !PathFileExists(windowsTerminalDir) && PathFileExists(conEmuDir))
 			{
 				cmderOptions.cmderIcon = szArgList[i + 1];
 				i++;
 			}
-			else if (_wcsicmp(L"/single", szArgList[i]) == 0 && !PathFileExists(windowsTerminalDir))
+			else if (_wcsicmp(L"/single", szArgList[i]) == 0 && !PathFileExists(windowsTerminalDir) && PathFileExists(conEmuDir))
 			{
 				cmderOptions.cmderSingle = true;
 			}
-			else if (_wcsicmp(L"/m", szArgList[i]) == 0 && !PathFileExists(windowsTerminalDir))
+			else if (_wcsicmp(L"/m", szArgList[i]) == 0 && !PathFileExists(windowsTerminalDir) && PathFileExists(conEmuDir))
 			{
 				cmderOptions.cmderUserCfg = false;
 			}
@@ -842,6 +866,13 @@ cmderOptions GetOption()
 			}
 		}
 
+	}
+
+	if (!PathFileExists(windowsTerminalDir) && !PathFileExists(conEmuDir))
+	{
+		cmderOptions.cmderTask = L"/k \"";
+		cmderOptions.cmderTask += cmdInit;
+		cmderOptions.cmderTask += L"\"";
 	}
 
 	if (cmderOptions.error == true)

--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -573,7 +573,7 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 			}
 			else if (streqi(cmderTask.c_str(), L"bash"))
 			{
-				swprintf_s(args, L"%s /k \"%s\"", args, initBash);
+				swprintf_s(args, L"%s /c \"%s\"", args, initBash);
 			}
 			else
 			{

--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -442,7 +442,7 @@ void StartCmder(std::wstring  path = L"", bool is_single_mode = false, std::wstr
 						exit(1);
 					}
 				}
-				}
+			}
 		}
 		else if (!CopyFile(defaultCfgPath, cfgPath, FALSE) && PathFileExists(conEmuDir))
 		{

--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -1,4 +1,4 @@
-#include <windows.h>/
+#include <windows.h>
 #include <tchar.h>
 #include <Shlwapi.h>
 #include "resource.h"

--- a/launcher/src/strings.rc2
+++ b/launcher/src/strings.rc2
@@ -6,7 +6,7 @@ STRINGTABLE
 {
 	IDS_TITLE             "Cmder Launcher"
 
-	IDS_SWITCHES          L"Valid options:\n\n    /c [CMDER User Root Path]\n    /task [Windows Terminal Profile/ConEmu Task Name]\n    /icon [CMDER Icon Path] - ConEmu ONLY!\n    [/start [Start in Path] | [Start in Path]]\n    /single - ConEmu ONLY!\n    /m\n    -- [ConEmu/Windows Terminal extra arguments]\n\nNote: '-- [...]' must be the last argument!\n\nor, either:\n    /register [USER | ALL]\n    /unregister [USER | ALL]"
+	IDS_SWITCHES          L"Valid options:\n\n    /a Admin - Native Terminals ONLY!\n    /c [CMDER User Root Path]\n    /task [Windows Terminal Profile/ConEmu Task Name]\n    /icon [CMDER Icon Path] - ConEmu ONLY!\n    [/start [Start in Path] | [Start in Path]]\n    /single - ConEmu ONLY!\n    /m\n    -- [ConEmu/Windows Terminal extra arguments]\n\nNote: '-- [...]' must be the last argument!\n\nor, either:\n    /register [USER | ALL]\n    /unregister [USER | ALL]"
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/scripts/pack.ps1
+++ b/scripts/pack.ps1
@@ -66,7 +66,7 @@ if ($terminal -eq "none") {
     $targets = @{
       "cmder_win.7z"       = "-t7z -m0=lzma2 -mx=9 -mfb=64 -md=32m -ms=on -myx=7 -mqs=on -xr!`"vendor\conemu-maximus5`" -xr!`"vendor\windows-terminal`"";
       "cmder_win.zip"      = "-mm=Deflate -mfb=128 -mpass=3 -xr!`"vendor\conemu-maximus5`" -xr!`"vendor\windows-terminal`"";
-      "cmder_win.mini.zip" = "-xr!`"vendor\git-for-windows`" -xr!`"vendor\conemu-maximus5`" -xr!`"vendor\windows-terminal`"";
+      "cmder_win_mini.zip" = "-xr!`"vendor\git-for-windows`" -xr!`"vendor\conemu-maximus5`" -xr!`"vendor\windows-terminal`"";
       "cmder_wt.7z"       = "-t7z -m0=lzma2 -mx=9 -mfb=64 -md=32m -ms=on -myx=7 -mqs=on -xr!`"vendor\conemu-maximus5`"";
       "cmder_wt.zip"      = "-mm=Deflate -mfb=128 -mpass=3 -xr!`"vendor\conemu-maximus5`"";
       "cmder_wt_mini.zip" = "-xr!`"vendor\git-for-windows`" -xr!`"vendor\conemu-maximus5`"";

--- a/scripts/pack.ps1
+++ b/scripts/pack.ps1
@@ -46,9 +46,9 @@ Ensure-Executable "7z"
 
 if ($terminal -eq "none") {
     $targets = @{
-      "cmder_slim.7z"       = "-t7z -m0=lzma2 -mx=9 -mfb=64 -md=32m -ms=on -myx=7 -mqs=on -xr!`"vendor\conemu-maximus5`" -xr!`"vendor\windows-terminal`"";
-      "cmder_slim.zip"      = "-mm=Deflate -mfb=128 -mpass=3 -xr!`"vendor\conemu-maximus5`" -xr!`"vendor\windows-terminal`"";
-      "cmder_slim_mini.zip" = "-xr!`"vendor\git-for-windows`" -xr!`"vendor\conemu-maximus5`" -xr!`"vendor\windows-terminal`"";
+      "cmder_win.7z"       = "-t7z -m0=lzma2 -mx=9 -mfb=64 -md=32m -ms=on -myx=7 -mqs=on -xr!`"vendor\conemu-maximus5`" -xr!`"vendor\windows-terminal`"";
+      "cmder_win.zip"      = "-mm=Deflate -mfb=128 -mpass=3 -xr!`"vendor\conemu-maximus5`" -xr!`"vendor\windows-terminal`"";
+      "cmder_win.mini.zip" = "-xr!`"vendor\git-for-windows`" -xr!`"vendor\conemu-maximus5`" -xr!`"vendor\windows-terminal`"";
     }
 } elseif ($terminal -eq "windows-terminal") {
     $targets = @{
@@ -64,9 +64,9 @@ if ($terminal -eq "none") {
     }
 } else {
     $targets = @{
-      "cmder_slim.7z"       = "-t7z -m0=lzma2 -mx=9 -mfb=64 -md=32m -ms=on -myx=7 -mqs=on -xr!`"vendor\conemu-maximus5`" -xr!`"vendor\windows-terminal`"";
-      "cmder_slim.zip"      = "-mm=Deflate -mfb=128 -mpass=3 -xr!`"vendor\conemu-maximus5`" -xr!`"vendor\windows-terminal`"";
-      "cmder_slim_mini.zip" = "-xr!`"vendor\git-for-windows`" -xr!`"vendor\conemu-maximus5`" -xr!`"vendor\windows-terminal`"";
+      "cmder_win.7z"       = "-t7z -m0=lzma2 -mx=9 -mfb=64 -md=32m -ms=on -myx=7 -mqs=on -xr!`"vendor\conemu-maximus5`" -xr!`"vendor\windows-terminal`"";
+      "cmder_win.zip"      = "-mm=Deflate -mfb=128 -mpass=3 -xr!`"vendor\conemu-maximus5`" -xr!`"vendor\windows-terminal`"";
+      "cmder_win.mini.zip" = "-xr!`"vendor\git-for-windows`" -xr!`"vendor\conemu-maximus5`" -xr!`"vendor\windows-terminal`"";
       "cmder_wt.7z"       = "-t7z -m0=lzma2 -mx=9 -mfb=64 -md=32m -ms=on -myx=7 -mqs=on -xr!`"vendor\conemu-maximus5`"";
       "cmder_wt.zip"      = "-mm=Deflate -mfb=128 -mpass=3 -xr!`"vendor\conemu-maximus5`"";
       "cmder_wt_mini.zip" = "-xr!`"vendor\git-for-windows`" -xr!`"vendor\conemu-maximus5`"";

--- a/vendor/start_git_mintty.cmd
+++ b/vendor/start_git_mintty.cmd
@@ -1,0 +1,40 @@
+@echo off
+
+if not defined CMDER_ROOT (
+    if defined ConEmuDir (
+        for /f "delims=" %%i in ("%ConEmuDir%\..\..") do (
+            set "CMDER_ROOT=%%~fi"
+        )
+    ) else (
+        for /f "delims=" %%i in ("%~dp0\..") do (
+            set "CMDER_ROOT=%%~fi"
+        )
+    )
+)
+
+if exist "%CMDER_ROOT%\vendor\git-for-windows" (
+  set "PATH=%CMDER_ROOT%\vendor\git-for-windows\usr\bin;%PATH%"
+  set "gitCmd=%CMDER_ROOT%\vendor\git-for-windows\usr\bin\mintty.exe"
+) else if exist "%ProgramFiles%\git" (
+  set "PATH=%ProgramFiles%\git\usr\bin;%PATH%"
+  set "gitCmd=%ProgramFiles%\git\usr\bin\mintty.exe"
+  if not exist "%ProgramFiles%\git\etc\profile.d\cmder_exinit.sh" (
+    echo Run 'mklink "%ProgramFiles%\git\etc\profile.d\cmder_exinit.sh" "%CMDER_ROOT%\vendor\cmder_exinit"' in 'cmd::Cmder as Admin' to use Cmder with external Git Bash
+    echo.
+    echo or
+    echo.
+    echo Run 'echo "" ^> "%ProgramFiles%\git\etc\profile.d\cmder_exinit.sh"' in 'cmd::Cmder as Admin' to disable this message.
+  )
+) else if exist "%ProgramFiles(x86)%\git" (
+  set "PATH=%ProgramFiles(x86)%\git\usr\bin;%PATH%"
+  set "gitCmd=%ProgramFiles(x86)%\git\usr\bin\mintty.exe"
+  if not exist "%ProgramFiles(x86)%\git\etc\profile.d\cmder_exinit.sh" (
+    echo Run 'mklink "%ProgramFiles^(x86^)%\git\etc\profile.d\cmder_exinit.sh" "%CMDER_ROOT%\vendor\cmder_exinit"' in 'cmd::Cmder as Admin' to use Cmder with external Git Bash
+    echo.
+    echo or
+    echo.
+    echo Run 'echo "" ^> "%ProgramFiles^(x86^)%\git\etc\profile.d\cmder_exinit.sh"' in 'cmd::Cmder as Admin' to disable this message.
+  )
+)
+
+"%gitCmd%" /bin/bash -l


### PR DESCRIPTION
### Adds

- When no external terminal emulator is available.
  - Add `Cmder.exe /task cmder [/a]`.
  - Add `Cmder.exe /task bash [/a]`.
  - Add `Cmder.exe /task mintty [/a]`.
  - Add `Cmder.exe /task powershell [/a]`.
  - New `Cmder.exe` command line argument `/a` used to start native terminal sessions as `Administrator`

![image](https://github.com/cmderdev/cmder/assets/7318053/4da7e2aa-5898-4b56-bcd4-ad08ebb72552)

- Running as Admin

![image](https://github.com/cmderdev/cmder/assets/7318053/d4780417-1b54-43ae-a6d8-d6b6d3eff5ae)
