### PR TITLE
Init bat cleanup

### DIFF
--- a/vendor/cmder.sh
+++ b/vendor/cmder.sh
@@ -49,6 +49,16 @@ if [[ ! "$PATH" =~ "${GIT_INSTALL_ROOT}/bin:" ]] ; then
   PATH="${GIT_INSTALL_ROOT}/bin:$PATH"
 fi
 
+if [ "$PROCESSOR_ARCHITECTURE" == "x86" ] &&  [ "$GIT_INSTALL_ROOT/mingw32" ] ; then
+  git_mingw_bin="$GIT_INSTALL_ROOT/mingw32/bin"
+elif [ "$PROCESSOR_ARCHITECTURE" == "AMD64" ] && [ -d "$GIT_INSTALL_ROOT/mingw64" ] ; then
+  git_mingw_bin="$GIT_INSTALL_ROOT/mingw64/bin"
+fi
+
+if [[ ! "$PATH" =~ "${git_mingw_bin}:" ]] ; then
+  PATH="${git_mingw_bin}:$PATH"
+fi
+
 PATH="${CMDER_ROOT}/bin:${CMDER_ROOT}/vendor/bin:$PATH:${CMDER_ROOT}"
 
 export PATH

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -166,7 +166,6 @@ if "%PROCESSOR_ARCHITECTURE%"=="x86" (
     set CMDER_CLINK=0
 )
 
-:: Use the generated user init snapshot when present. Shared config keeps precedence.
 set "cmder_root_user_init=%CMDER_ROOT%\config\user_init.cmd"
 if defined CMDER_USER_CONFIG set "cmder_user_init=%CMDER_USER_CONFIG%\user_init.cmd"
 
@@ -239,7 +238,7 @@ goto :SKIP_CLINK
 
     :: Revert back to plain cmd.exe prompt without clink
     prompt $E[1;32;49m$P$S$_$E[1;30;49mλ$S$E[0m
-    
+
     :: Add Windows Terminal shell integration support (OSC 133 sequences)
     if defined WT_SESSION (prompt $e]133;D$e\$e]133;A$e\$e]9;9;$P$e\%PROMPT%$e]133;B$e\)
 

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -345,17 +345,15 @@ if %nix_tools% equ 1 (
 )
 
 %print_debug% init.bat "START - nix_tools(%path_position%): Env Var - PATH=%path%"
-if %nix_tools% geq 1 (
-    set "git_mingw_bin="
-    if exist "%GIT_INSTALL_ROOT%\mingw32" (
-        set "git_mingw_bin=%GIT_INSTALL_ROOT%\mingw32\bin"
-    ) else if exist "%GIT_INSTALL_ROOT%\mingw64" (
-        set "git_mingw_bin=%GIT_INSTALL_ROOT%\mingw64\bin"
-    )
-
-    %lib_path% add_path_with_position "%git_mingw_bin%" "%path_position%"
-    %lib_path% add_path_with_position "%GIT_INSTALL_ROOT%\usr\bin" "%path_position%"
+set "git_mingw_bin="
+if exist "%GIT_INSTALL_ROOT%\mingw32" (
+    set "git_mingw_bin=%GIT_INSTALL_ROOT%\mingw32\bin"
+) else if exist "%GIT_INSTALL_ROOT%\mingw64" (
+    set "git_mingw_bin=%GIT_INSTALL_ROOT%\mingw64\bin"
 )
+
+%lib_path% add_path_with_position "%git_mingw_bin%" "%path_position%"
+%lib_path% add_path_with_position "%GIT_INSTALL_ROOT%\usr\bin" "%path_position%"
 %print_debug% init.bat "END - nix_tools(%path_position%): Env Var - PATH=%path%"
 
 :SET_ENV

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -137,14 +137,14 @@ if %verbose_output% gtr 0 (
 %print_debug% init.bat "Env Var - debug_output=%debug_output%"
 
 :: Set the Cmder directory paths
-set CMDER_CONFIG_DIR=%CMDER_ROOT%\config
+set "CMDER_CONFIG_DIR=%CMDER_ROOT%\config"
 
 :: Check if we're using Cmder individual user profile
 if defined CMDER_USER_CONFIG (
     %print_debug% init.bat "CMDER IS ALSO USING INDIVIDUAL USER CONFIG FROM '%CMDER_USER_CONFIG%'!"
 
     if not exist "%CMDER_USER_CONFIG%\..\opt" md "%CMDER_USER_CONFIG%\..\opt"
-    set CMDER_CONFIG_DIR=%CMDER_USER_CONFIG%
+    set "CMDER_CONFIG_DIR=%CMDER_USER_CONFIG%"
 )
 
 if not "%CMDER_SHELL%" == "cmd" (
@@ -166,16 +166,17 @@ if "%PROCESSOR_ARCHITECTURE%"=="x86" (
     set CMDER_CLINK=0
 )
 
-if defined CMDER_USER_CONFIG (
-  if exist "%CMDER_ROOT%\config\user_init.cmd" (
-    call "%CMDER_ROOT%\config\user_init.cmd"
-    exit /b
-  ) else if exist "%CMDER_USER_CONFIG%\config\user_init.cmd" (
-    call "%CMDER_USER_CONFIG%\config\user_init.cmd"
-    exit /b
-  )
-) else if exist "%CMDER_ROOT%\config\user_init.cmd" (
-  call "%CMDER_ROOT%\config\user_init.cmd"
+:: Use the generated user init snapshot when present. Shared config keeps precedence.
+set "cmder_root_user_init=%CMDER_ROOT%\config\user_init.cmd"
+if defined CMDER_USER_CONFIG set "cmder_user_init=%CMDER_USER_CONFIG%\user_init.cmd"
+
+if exist "%cmder_root_user_init%" (
+  call "%cmder_root_user_init%"
+  exit /b
+)
+
+if defined CMDER_USER_CONFIG if exist "%cmder_user_init%" (
+  call "%cmder_user_init%"
   exit /b
 )
 
@@ -346,26 +347,15 @@ if %nix_tools% equ 1 (
 
 %print_debug% init.bat "START - nix_tools(%path_position%): Env Var - PATH=%path%"
 if %nix_tools% geq 1 (
+    set "git_mingw_bin="
     if exist "%GIT_INSTALL_ROOT%\mingw32" (
-        if "%path_position%" == "append" (
-          set "path=%path%;%GIT_INSTALL_ROOT%\mingw32\bin"
-        ) else (
-          set "path=%GIT_INSTALL_ROOT%\mingw32\bin;%path%"
-        )
+        set "git_mingw_bin=%GIT_INSTALL_ROOT%\mingw32\bin"
     ) else if exist "%GIT_INSTALL_ROOT%\mingw64" (
-        if "%path_position%" == "append" (
-          set "path=%path%;%GIT_INSTALL_ROOT%\mingw64\bin"
-        ) else (
-          set "path=%GIT_INSTALL_ROOT%\mingw64\bin;%path%"
-        )
+        set "git_mingw_bin=%GIT_INSTALL_ROOT%\mingw64\bin"
     )
-    if exist "%GIT_INSTALL_ROOT%\usr\bin" (
-        if "%path_position%" == "append" (
-          set "path=%path%;%GIT_INSTALL_ROOT%\usr\bin"
-        ) else (
-          set "path=%GIT_INSTALL_ROOT%\usr\bin;%path%"
-        )
-    )
+
+    %lib_path% add_path_with_position "%git_mingw_bin%" "%path_position%"
+    %lib_path% add_path_with_position "%GIT_INSTALL_ROOT%\usr\bin" "%path_position%"
 )
 %print_debug% init.bat "END - nix_tools(%path_position%): Env Var - PATH=%path%"
 
@@ -421,12 +411,12 @@ if %max_depth% gtr 1 (
 )
 %print_debug% init.bat "END - bin(prepend): Env Var - PATH=%path%"
 
-if defined CMDER_USER_BIN if defined CMDER_USER_ROOT (
+if defined CMDER_USER_BIN (
   %print_debug% init.bat "START - user_bin(prepend): Env Var - PATH=%path%"
   if %max_depth% gtr 1 (
     %lib_path% enhance_path_recursive "%CMDER_USER_BIN%" 0 %max_depth%
   ) else (
-    set "path=%CMDER_USER_ROOT%\bin;%path%"
+    set "path=%CMDER_USER_BIN%;%path%"
   )
   %print_debug% init.bat "END - user_bin(prepend): Env Var - PATH=!path!"
 )
@@ -560,6 +550,8 @@ if not exist "%CMDER_CONFIG_DIR%\user_init.cmd" (
 
 :CLEANUP
   set architecture_bits=
+  set cmder_root_user_init=
+  set cmder_user_init=
   set CMDER_ALIASES=
   set CMDER_INIT_END=
   set CMDER_INIT_START=
@@ -567,6 +559,7 @@ if not exist "%CMDER_CONFIG_DIR%\user_init.cmd" (
   set CMDER_CLINK=
   set debug_output=
   set fast_init=
+  set git_mingw_bin=
   set max_depth=
   set nix_tools=
   set path_position=

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -408,6 +408,7 @@ if %max_depth% gtr 1 (
 )
 %print_debug% init.bat "END - bin(prepend): Env Var - PATH=%path%"
 
+:: The CMDER_USER_BIN variable is set in the launcher.
 if defined CMDER_USER_BIN (
   %print_debug% init.bat "START - user_bin(prepend): Env Var - PATH=%path%"
   if %max_depth% gtr 1 (

--- a/vendor/lib/lib_base.cmd
+++ b/vendor/lib/lib_base.cmd
@@ -98,10 +98,9 @@ exit /b
 :::.
 :::       This function checks if the user_aliases file contains the marker
 :::       ";= Add aliases below here". If the marker is not found, it creates
-:::       an initial user_aliases store by copying the default user_aliases file
-:::       from the CMDER_ROOT directory. If the CMDER_USER_CONFIG environment
-:::       variable is defined, it creates a backup of the existing user_aliases
-:::       file before copying the default file.
+:::       an initial user_aliases store by backing up the existing file to
+:::       `*.old_format` and then copying the default user_aliases file from
+:::       the CMDER_ROOT directory.
 :::.
 :::include:
 :::.
@@ -116,12 +115,7 @@ exit /b
     type "%user_aliases%" | %WINDIR%\System32\findstr /i ";= Add aliases below here" >nul
     if "%errorlevel%" == "1" (
         echo Creating initial user_aliases store in "%user_aliases%"...
-        if defined CMDER_USER_CONFIG (
-            copy "%user_aliases%" "%user_aliases%.old_format"
-            copy "%CMDER_ROOT%\vendor\user_aliases.cmd.default" "%user_aliases%"
-        ) else (
-            copy "%user_aliases%" "%user_aliases%.old_format"
-            copy "%CMDER_ROOT%\vendor\user_aliases.cmd.default" "%user_aliases%"
-        )
+        copy "%user_aliases%" "%user_aliases%.old_format"
+        copy "%CMDER_ROOT%\vendor\user_aliases.cmd.default" "%user_aliases%"
     )
     exit /b

--- a/vendor/lib/lib_path.cmd
+++ b/vendor/lib/lib_path.cmd
@@ -149,9 +149,44 @@ exit /b
 
     exit /b
 
+:add_path_with_position
+:::===============================================================================
+:::add_path_with_position - Add a directory to PATH at the start or end.
+:::
+:::include:
+:::
+:::  call "lib_path.cmd"
+:::
+:::usage:
+:::
+:::  %lib_path% add_path_with_position "[dir_path]" [append]
+:::
+:::required:
+:::
+:::  [dir_path] <in> Fully qualified directory path. Ex: "c:\bin"
+:::
+:::options:
+:::
+:::  append     <in> Append to the path env variable rather than pre-pend.
+:::
+:::output:
+:::
+:::  path       <out> Updates the path env variable when the directory exists.
+:::-------------------------------------------------------------------------------
+    if "%~1" == "" exit /b
+    if not exist "%~1" exit /b
+
+    if /i "%~2" == "append" (
+       set "path=%path%;%~1"
+    ) else (
+       set "path=%~1;%path%"
+    )
+
+    exit /b
+
 :set_found
     if "%ERRORLEVEL%" == "0" (
-        set found=1
+       set found=1
     )
 
     exit /b

--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -292,4 +292,6 @@ $CMDER_INIT_END = Get-Date
 
 $ElapsedTime = New-TimeSpan -Start $CMDER_INIT_START -End $CMDER_INIT_END
 
+$env:Path = $env:Path -replace ';;', ';'
+
 Write-Verbose "Elapsed Time: $($ElapsedTime.TotalSeconds) seconds total"

--- a/vendor/user_init.cmd.template
+++ b/vendor/user_init.cmd.template
@@ -93,14 +93,6 @@ goto :SKIP_CLINK
   %lib_path% add_path_with_position "%git_mingw_bin%" "%path_position%"
   %lib_path% add_path_with_position "%GIT_INSTALL_ROOT%\usr\bin" "%path_position%"
 
-  if exist "%GIT_INSTALL_ROOT%\usr\bin" (
-      if "%path_position%" == "append" (
-        set "path=%path%;%GIT_INSTALL_ROOT%\usr\bin"
-      ) else (
-        set "path=%GIT_INSTALL_ROOT%\usr\bin;%path%"
-      )
-  )
-
   set "path=%CMDER_ROOT%\vendor\bin;%path%"
 
 :USER_CONFIG_START

--- a/vendor/user_init.cmd.template
+++ b/vendor/user_init.cmd.template
@@ -118,7 +118,7 @@ goto :SKIP_CLINK
     if %max_depth% gtr 1 (
       %lib_path% enhance_path_recursive "%CMDER_USER_BIN%" 0 %max_depth%
     ) else (
-      set "path=%CMDER_USER_ROOT%\bin;%path%"
+      set "path=%CMDER_USER_BIN%;%path%"
     )
   )
   endlocal && set "path=%path%"
@@ -139,7 +139,7 @@ goto :SKIP_CLINK
     )
   )
   
-  set "path=%path:;;=;%
+  set "path=%path:;;=;%"
 
 :CMDER_CONFIGURED
   if not defined CMDER_CONFIGURED set CMDER_CONFIGURED=1
@@ -170,5 +170,4 @@ goto :SKIP_CLINK
   set user_aliases=
 
 exit /b
-
 

--- a/vendor/user_init.cmd.template
+++ b/vendor/user_init.cmd.template
@@ -10,6 +10,13 @@
 :: powershell -f %cmder_root%\vendor\bin\create-cmdercfg.ps1 -shell cmd [-outfile "[filename]"]
 ::
 
+:: TODO: Support for ARM
+if "%PROCESSOR_ARCHITECTURE%"=="x86" (
+    set architecture_bits=32
+) else if "%PROCESSOR_ARCHITECTURE%"=="AMD64" (
+    set architecture_bits=64
+)
+
 if "%CMDER_CLINK%" == "1" (
   goto :INJECT_CLINK
 ) else if "%CMDER_CLINK%" == "2" if defined WT_PROFILE_ID (
@@ -81,26 +88,20 @@ goto :SKIP_CLINK
       set "path_position="
   )
   
-  if %nix_tools% geq 1 (
-      if exist "%GIT_INSTALL_ROOT%\mingw32" (
-          if "%path_position%" == "append" (
-            set "path=%path%;%GIT_INSTALL_ROOT%\mingw32\bin"
-          ) else (
-            set "path=%GIT_INSTALL_ROOT%\mingw32\bin;%path%"
-          )
-      ) else if exist "%GIT_INSTALL_ROOT%\mingw64" (
-          if "%path_position%" == "append" (
-            set "path=%path%;%GIT_INSTALL_ROOT%\mingw64\bin"
-          ) else (
-            set "path=%GIT_INSTALL_ROOT%\mingw64\bin;%path%"
-          )
-      )
-      if exist "%GIT_INSTALL_ROOT%\usr\bin" (
-          if "%path_position%" == "append" (
-            set "path=%path%;%GIT_INSTALL_ROOT%\usr\bin"
-          ) else (
-            set "path=%GIT_INSTALL_ROOT%\usr\bin;%path%"
-          )
+  if "%architecture_bits%" == "32" if exist "%GIT_INSTALL_ROOT%\mingw32" (
+      set "git_mingw_bin=%GIT_INSTALL_ROOT%\mingw32\bin
+  ) else if "%architecture_bits%" == "64" if exist "%GIT_INSTALL_ROOT%\mingw64" (
+      set "git_mingw_bin=%GIT_INSTALL_ROOT%\mingw64\bin
+  )
+
+  %lib_path% add_path_with_position "%git_mingw_bin%" "%path_position%"
+  %lib_path% add_path_with_position "%GIT_INSTALL_ROOT%\usr\bin" "%path_position%"
+
+  if exist "%GIT_INSTALL_ROOT%\usr\bin" (
+      if "%path_position%" == "append" (
+        set "path=%path%;%GIT_INSTALL_ROOT%\usr\bin"
+      ) else (
+        set "path=%GIT_INSTALL_ROOT%\usr\bin;%path%"
       )
   )
   
@@ -168,6 +169,7 @@ goto :SKIP_CLINK
   set time_init=
   set verbose_output=
   set user_aliases=
+  set "PATH=%PATH:;;=;%"
 
 exit /b
 

--- a/vendor/user_init.cmd.template
+++ b/vendor/user_init.cmd.template
@@ -10,13 +10,6 @@
 :: powershell -f %cmder_root%\vendor\bin\create-cmdercfg.ps1 -shell cmd [-outfile "[filename]"]
 ::
 
-:: TODO: Support for ARM
-if "%PROCESSOR_ARCHITECTURE%"=="x86" (
-    set architecture_bits=32
-) else if "%PROCESSOR_ARCHITECTURE%"=="AMD64" (
-    set architecture_bits=64
-)
-
 if "%CMDER_CLINK%" == "1" (
   goto :INJECT_CLINK
 ) else if "%CMDER_CLINK%" == "2" if defined WT_PROFILE_ID (
@@ -76,22 +69,25 @@ goto :SKIP_CLINK
   if not defined user_aliases     set "user_aliases=$env:user_aliases"
   if not defined aliases          set "aliases=%user_aliases%"
   if not defined HOME             set "HOME=%USERPROFILE%"
-  
+
   set PLINK_PROTOCOL=$env:PLINK_PROTOCOL
-  
+
   set "path=%GIT_INSTALL_ROOT%\cmd;%path%"
-  
+
   set path_position=append
   if %nix_tools% equ 1 (
       set "path_position=append"
   ) else (
       set "path_position="
   )
-  
-  if "%architecture_bits%" == "32" if exist "%GIT_INSTALL_ROOT%\mingw32" (
+
+  :: TODO: Support for ARM
+  if "%PROCESSOR_ARCHITECTURE%" == "x86" if exist "%GIT_INSTALL_ROOT%\mingw32" (
       set "git_mingw_bin=%GIT_INSTALL_ROOT%\mingw32\bin
-  ) else if "%architecture_bits%" == "64" if exist "%GIT_INSTALL_ROOT%\mingw64" (
+    )
+  ) else if "%PROCESSOR_ARCHITECTURE%" == "AMD64" if exist "%GIT_INSTALL_ROOT%\mingw64" (
       set "git_mingw_bin=%GIT_INSTALL_ROOT%\mingw64\bin
+    )
   )
 
   %lib_path% add_path_with_position "%git_mingw_bin%" "%path_position%"
@@ -104,7 +100,7 @@ goto :SKIP_CLINK
         set "path=%GIT_INSTALL_ROOT%\usr\bin;%path%"
       )
   )
-  
+
   set "path=%CMDER_ROOT%\vendor\bin;%path%"
 
 :USER_CONFIG_START
@@ -113,7 +109,7 @@ goto :SKIP_CLINK
   ) else (
     set "path=%CMDER_ROOT%\bin;%path%"
   )
-  
+
   setlocal enabledelayedexpansion
   if defined CMDER_USER_BIN (
     if %max_depth% gtr 1 (
@@ -123,30 +119,30 @@ goto :SKIP_CLINK
     )
   )
   endlocal && set "path=%path%"
-   
+
   set "path=%path%;%CMDER_ROOT%"
-  
+
   call "%user_aliases%"
-  
+
   %lib_profile% run_profile_d "%CMDER_ROOT%\config\profile.d"
   if defined CMDER_USER_CONFIG (
     %lib_profile% run_profile_d "%CMDER_USER_CONFIG%\profile.d"
   )
-  
+
   call "%CMDER_ROOT%\config\user_profile.cmd"
   if defined CMDER_USER_CONFIG (
     if exist "%CMDER_USER_CONFIG%\user_profile.cmd" (
       call "%CMDER_USER_CONFIG%\user_profile.cmd"
     )
   )
-  
+
   set "path=%path:;;=;%"
 
 :CMDER_CONFIGURED
   if not defined CMDER_CONFIGURED set CMDER_CONFIGURED=1
-  
+
   set CMDER_INIT_END=%time%
-  
+
   if "%time_init%" == "1" if "%CMDER_INIT_END%" neq "" if "%CMDER_INIT_START%" neq "" (
     call "%cmder_root%\vendor\bin\timer.cmd" "%CMDER_INIT_START%" "%CMDER_INIT_END%"
   )


### PR DESCRIPTION
- Cleaned up the code for easier reading and maintenance.
- Provides more consistent pat settings accross all three shells.