### PR TITLE
ci: read the PR head ref from the environment instead of interpolating it into PowerShell

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,8 @@ jobs:
 
     - name: Summary - Repository checkout
       shell: pwsh
+      env:
+        HEAD_REF: ${{ github.head_ref }}
       run: |
         # Get Cmder version
         . scripts/utils.ps1
@@ -50,7 +52,7 @@ jobs:
 
         # Determine branch and PR information
         $refName = "${{ github.ref_name }}"
-        $headRef = "${{ github.head_ref }}"
+        $headRef = $env:HEAD_REF
         $eventName = "${{ github.event_name }}"
         $prNumber = $null
         $actualBranchName = $refName


### PR DESCRIPTION
Hi, and thanks for Cmder.

In `.github/workflows/build.yml`, the "Summary - Repository checkout" step reads the PR's source branch name into PowerShell by interpolation:

```powershell
$refName = "${{ github.ref_name }}"
$headRef = "${{ github.head_ref }}"
$eventName = "${{ github.event_name }}"
```

Actions substitutes `${{ ... }}` into the script text before PowerShell parses it, so the branch name becomes part of the script rather than a string. PowerShell expands `$(...)` inside double-quoted strings, and git allows `$`, `(` and `)` in branch names — so a PR from a fork on a branch named something like `x$(...)` would run that rather than being assigned to `$headRef`.

Scope, so I am not overstating it: the workflow triggers on `pull_request`, so a fork PR gets a read-only token and no secrets. This is hardening.

The change reads that one value from the environment:

```yaml
env:
  HEAD_REF: ${{ github.head_ref }}
run: |
  $headRef = $env:HEAD_REF
```

I deliberately left `$refName` and `$eventName` as they are: `github.ref_name` on this workflow's own runs and `github.event_name` are GitHub-controlled values with fixed shapes, not attacker-supplied free text, so they do not carry the same problem and I did not want to widen the diff beyond what is actually at issue.

I noticed the same `$headRef = "${{ github.head_ref }}"` line in `codeql.yml` and `tests.yml`. I have kept this PR to `build.yml` so it stays easy to review — happy to send the same one-line change for the other two if you would like it, or to fold them in here, whichever you prefer.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the workflows myself.
